### PR TITLE
'Status' param in library endpoint

### DIFF
--- a/docs/source/misc/external_api.rst
+++ b/docs/source/misc/external_api.rst
@@ -65,6 +65,7 @@ GET /1.0/library
    - purchased_after: [RFC3339](https://tools.ietf.org/html/rfc3339) (e.g. `2000-01-01T00:00:00Z`)
    - response_groups: [contributors, media, price, product_attrs, product_desc, product_extended_attrs, product_plan_details, product_plans, rating, sample, sku, series, reviews, ws4v, origin, relationships, review_attrs, categories, badge_types, category_ladders, claim_code_url, is_downloaded, is_finished, is_returnable, origin_asin, pdf_url, percent_complete, provided_review]
    - sort_by: [-Author, -Length, -Narrator, -PurchaseDate, -Title, Author, Length, Narrator, PurchaseDate, Title]
+   - status: [Active, Revoked] ('Active' is the default, 'Revoked' returns audiobooks the user has returned for a refund.)
 
 GET /1.0/library/%{asin}
 ------------------------


### PR DESCRIPTION
Specifying 'status' in the call to '1.0/library' allows retrieving audiobooks that have been returned