### PR TITLE
Access name and value attributes via dict.get()

### DIFF
--- a/src/audible/login.py
+++ b/src/audible/login.py
@@ -53,7 +53,7 @@ def get_soup(resp):
 def get_inputs_from_soup(soup) -> Dict[str, str]:
     inputs = {}
     for node in soup.select("input[type=hidden]"):
-        if node["name"] and node["value"]:
+        if node.attrs.get("name") and node.attrs.get("value"):
             inputs[node["name"]] = node["value"]
     return inputs
 


### PR DESCRIPTION
Using node['key'] can potentially result in KeyError, halting the entire program. dict.get() is safer.