### PR TITLE
Issue #28: Provide approval alert callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fetched activation bytes (with ``extract=True`` argument) will be stored to ``activation_bytes`` attribute of Authenticator class instance for now. Ignore existing activation bytes and force refresh with ``auth.get_activation_bytes(force_refresh=True)``
 - ``activation_bytes`` will be loaded from and save  to file. Saved auth files are **not backward compatible** to previous audible versions so keep old files save.
-- `Client.raw_request` and `AsyncClient.raw_request` method.
+- Add ``Client.raw_request`` and ``AsyncClient.raw_request`` method.
+- Provide a custom Callback with ``approval_callback`` keyword argument when login.
 
 ## [0.5.0] - 2020-12-07
 

--- a/docs/source/auth/authorization.rst
+++ b/docs/source/auth/authorization.rst
@@ -100,3 +100,18 @@ prompt which looks like::
 
 Please approve the amazon email notification and press enter (or another key)
 to proceed.
+
+A custom callback can be provided, like so::
+
+   def custom_approval_callback():
+    
+       # You can let python check for the received Amazon mail and 
+       # open the approval link. The login function wait until
+       # the callback function is executed. The returned value will be
+       # ignored by the login function.
+       
+
+   auth = audible.Authenticator.from_login(
+       ...
+       approval_callback=custom_approval_callback
+       )

--- a/src/audible/auth.py
+++ b/src/audible/auth.py
@@ -318,7 +318,8 @@ class Authenticator(httpx.Auth):
                    register: bool = False,
                    captcha_callback: Optional[Callable[[str], str]] = None,
                    otp_callback: Optional[Callable[[], str]] = None,
-                   cvf_callback: Optional[Callable[[], str]] = None
+                   cvf_callback: Optional[Callable[[], str]] = None,
+                   approval_callback: Optional[Callable[[], Any]] = None
                    ) -> "Authenticator":
         """Instantiate a new Authenticator with authentication data from login.
 
@@ -331,11 +332,12 @@ class Authenticator(httpx.Auth):
                 instance for the marketplace to login.
             register: If ``True``, register a new device after login.
             captcha_callback: A custom callback to handle captcha requests
-                during login
+                during login.
             otp_callback: A custom callback to handle one-time password
                 requests during login.
             cvf_callback: A custom callback to handle verify code requests
                 during login.
+            approval_callback: A custom Callable for handling approval alerts.
 
         Returns:
             An :class:`~audible.auth.Authenticator` instance.
@@ -348,7 +350,8 @@ class Authenticator(httpx.Auth):
             password=password,
             captcha_callback=captcha_callback,
             otp_callback=otp_callback,
-            cvf_callback=cvf_callback)
+            cvf_callback=cvf_callback,
+            approval_callback=approval_callback)
 
         logger.info(f"logged in to Audible as {username}")
 
@@ -511,7 +514,8 @@ class Authenticator(httpx.Auth):
                  password: str,
                  captcha_callback: Optional[Callable[[str], str]] = None,
                  otp_callback: Optional[Callable[[], str]] = None,
-                 cvf_callback: Optional[Callable[[], str]] = None) -> None:
+                 cvf_callback: Optional[Callable[[], str]] = None,
+                 approval_callback: Optional[Callable[[], Any]] = None) -> None:
 
         login_device = login(
             username=username,
@@ -521,7 +525,8 @@ class Authenticator(httpx.Auth):
             market_place_id=self.locale.market_place_id,
             captcha_callback=captcha_callback,
             otp_callback=otp_callback,
-            cvf_callback=cvf_callback)
+            cvf_callback=cvf_callback,
+            approval_callback=approval_callback)
 
         self._update_attrs(**login_device)
 

--- a/src/audible/login.py
+++ b/src/audible/login.py
@@ -150,7 +150,8 @@ def login(
     market_place_id: str,
     captcha_callback: Optional[Callable[[str], str]] = None,
     otp_callback: Optional[Callable[[], str]] = None,
-    cvf_callback: Optional[Callable[[], str]] = None
+    cvf_callback: Optional[Callable[[], str]] = None,
+    approval_callback: Optional[Callable[[], Any]] = None
 ) -> Dict[str, Any]:
     """Login to Audible by simulating an Audible App for iOS.
     
@@ -164,8 +165,10 @@ def login(
             If ``None`` :func:`default_captcha_callback` is used.
         otp_callback: A custom Callable for providing one-time passwords.
             If ``None`` :func:`default_otp_callback` is used.
-        cvf_callback: A custom Callback for providing the answer for a CVF code.
+        cvf_callback: A custom Callable for providing the answer for a CVF code.
             If ``None`` :func:`default_cvf_callback` is used.
+        approval_callback: A custom Callable for handling approval alerts.
+            If ``None`` :func:`default_approval_alert_callback` is used.
     
     Returns:
         An ``access_token`` with ``expires`` timestamp and the 
@@ -266,7 +269,11 @@ def login(
 
     # check for approval alert
     while check_for_approval_alert(login_soup):
-        default_approval_alert_callback()
+        if approval_callback:
+            approval_callback()
+        else:
+            default_approval_alert_callback()
+
         url = login_soup.find_all("a", class_="a-link-normal")[1]["href"]
 
         login_resp = session.get(url)


### PR DESCRIPTION
Provide a custom approval alert callback with `approval_callback` keyword argument when login. 