### PR TITLE
Update external_api.rst

### DIFF
--- a/docs/source/misc/external_api.rst
+++ b/docs/source/misc/external_api.rst
@@ -412,7 +412,7 @@ POST /1.0/content/%{asin}/licenserequest
 :body:
    - supported_drm_types: [Mpeg, Adrm]
    - consumption_type: [Streaming, Offline, Download]
-   - drm_type: [Hls, PlayReady, Hds, Adrm]
+   - drm_type: [Mpeg, PlayReady, Hls, Dash, FairPlay, Widevine, HlsCmaf, Adrm]
    - quality: [High, Normal, Extreme, Low]
    - num_active_offline_licenses: \\d+ (max: 10)
    - response_groups: [last_position_heard,pdf_url,content_reference,chapter_info]


### PR DESCRIPTION
Server returned error on request containing "drm_type" = "Hds"

Error message:
"1 validation error detected: Value 'Hds' at 'drmType' failed to satisfy constraint: Member must satisfy enum value set: [Mpeg, PlayReady, Hls, Dash, FairPlay, Widevine, HlsCmaf, Adrm]"