### PR TITLE
updating capture of `method` and `url`

### DIFF
--- a/src/audible/login.py
+++ b/src/audible/login.py
@@ -123,8 +123,8 @@ def get_next_action_from_soup(
         soup: BeautifulSoup, search_field: Optional[Dict[str, str]] = None
 ) -> Tuple[str, str]:
     form = soup.find("form", search_field) or soup.find("form")
-    method = form["method"]
-    url = form["action"]
+    method = form["attrs"]["method"]
+    url = form["attrs"]["action"]
 
     return method, url
     


### PR DESCRIPTION
When digging through the soup, the extraction of both the `method` and `url` were buried one level deep in `"attrs"` key, without this change it was giving me `KeyError` exceptions. This change should fix it.