### PR TITLE
update get_next_action_from_soup()

### DIFF
--- a/src/audible/login.py
+++ b/src/audible/login.py
@@ -122,7 +122,11 @@ def get_inputs_from_soup(
 def get_next_action_from_soup(
         soup: BeautifulSoup, search_field: Optional[Dict[str, str]] = None
 ) -> Tuple[str, str]:
-    form = soup.find("form", search_field) or soup.find("form")
+    form = None
+    if search_field is not None:
+        form = soup.find("form", search_field)
+    else:
+        form = soup.find("form")
     method = form["method"]
     url = form["action"]
 


### PR DESCRIPTION
When using a custom captcha callback, `get_next_action_from_soup()` was not returning the right `form` from the `login_soup`, and then would crash due to a `KeyError` when it wouldn't return the first `form` found in the soup, that didn't have a key of either `'method'` or `'action'`. 

The `or` operator had some strange side effects where it was returning the second `form` found in a return for the captcha. Debugging it using `soup.find_all('form')` on the `login_soup` would return multiple form items, and for some reason even when `search_field` was set to `None`, it would return the form found at index 1 instead of index 0. 

Splitting it in the way I have here was able to get it to return the correct info as expected.