### PR TITLE
V0.8.0dev

### DIFF
--- a/.github/workflows/pypi-publish-test.yml
+++ b/.github/workflows/pypi-publish-test.yml
@@ -7,7 +7,7 @@ jobs:
   build-n-publish:
     name: Build and publish Audible to TestPyPI
     runs-on: ubuntu-18.04
-    
+
     steps:
       - uses: actions/checkout@master
       - name: Set up Python 3.9

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ jobs:
   build-n-publish:
     name: Build and publish Audible to PyPI
     runs-on: ubuntu-18.04
-    
+
     steps:
       - uses: actions/checkout@master
       - name: Set up Python 3.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - full support of pre-Amazon accounts (e.g. refresh access token, deregister device)
 - `Client` and `AsynClient` now accepts session kwargs which are bypassed to the underlying httpx Client
 - a `respone_callback` can now be set to `Client` and `AsyncClient` class to allow custom preparation of response output
+- An absolut url (e.g. https://cde-ta-g7g.amazon.com/FionaCDEServiceEngine/sidecar) can now be passed to a client `get`, `post`, `delete` and `put` method as the `path` arg. So in most cases the client `raw_request` method is not needed anymore.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 -
 
+## [0.7.2] - 2022-03-27
+
+### Bugfix
+
+- fix a bug in registration url 
+
 ## [0.7.1] - 2022-03-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
--
-
 ### Added
 
 - full support of pre-Amazon accounts (e.g. refresh access token, deregister device)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 -
 
+### Added
+
+- full support of pre-Amazon accounts (e.g. refresh access token, deregister device)
+- `Client` and `AsynClient` now accepts session kwargs which are bypassed to the underlying httpx Client
+
+### Changed
+
+- rename (and rework) `Client._split_kwargs` to `Client._prepare_params`
+
 ## [0.7.2] - 2022-03-27
 
 ### Bugfix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - full support of pre-Amazon accounts (e.g. refresh access token, deregister device)
 - `Client` and `AsynClient` now accepts session kwargs which are bypassed to the underlying httpx Client
+- a `respone_callback` can now be set to `Client` and `AsyncClient` class to allow custom preparation of response output
 
 ### Changed
 

--- a/docs/source/auth/authentication.rst
+++ b/docs/source/auth/authentication.rst
@@ -25,7 +25,9 @@ Sign request method
 With the sign request method you gain unrestricted access to the Audible API.
 To use this method, you need the RSA private key and the adp_token from a
 *device registration*. This method is used by the Audible apps for iOS and
-Android too.
+Android too. A device registration is done automatically with
+:meth:`audible.Authenticator.from_login` or
+:meth:`audible.Authenticator.from_login_external`
 
 Request signing is fairly straight-forward and uses a signed SHA256 digest.
 Headers look like::
@@ -37,8 +39,8 @@ Headers look like::
 Bearer method
 -------------
 
-API requests with the bearer method are restricted. Some API call like the
-:http:post:`/1.0/content/(string:asin)/licenserequest` doesn't work. To use
+API requests with the bearer method have some restrictions. Some API call, like
+the :http:post:`/1.0/content/(string:asin)/licenserequest`, doesn't work. To use
 the bearer method you need an access token and a client id. You receive the
 token after a device registration. Which values are valid for the client-id 
 is unknown but 0 does work. An access token expires after 60 minutes. It 

--- a/docs/source/auth/authorization.rst
+++ b/docs/source/auth/authorization.rst
@@ -148,7 +148,7 @@ To handle the login with a external browser or program logic you can do the foll
    auth = audible.Authenticator.from_login_external(locale=COUNTRY_CODE)
 
 By default, this code print out the login url for the selected country code. Now you have
-to copy and paste this code into a webbrowser (or a custom program) and authorize yourself. 
+to copy and paste this code into a web browser (or a custom program) and authorize yourself.
 You have to enter your credentials two times (because of missing init cookies). 
 On first time, the password can be a random one.
 On second time, you have to solve a captcha before you can submit the login form with your 
@@ -157,6 +157,11 @@ After authorize successfully you will end in an error page (not found). This is 
 Please copy the url from the address bar from your browser and paste the url to the input 
 field of the python code. This url looks like 
 "https://www.amazon.{domain}/ap/maplanding?...&openid.oa2.authorization_code=..."
+
+.. note::
+   If you have `playwright <https://pypi.org/project/playwright/>`_ installed and
+   use the default ``login_url_callback``, a new browser is opened, where you can
+   authorize to your account,
 
 .. note::
 

--- a/docs/source/auth/register.rst
+++ b/docs/source/auth/register.rst
@@ -17,6 +17,8 @@ To authorize and register a new device you can do::
        with_username=False,
    )
 
+This will authorize you to your account and register an Audible device.
+
 .. important::
 
    Every device registration will be shown on the Amazon devices list. So only

--- a/docs/source/intro/getting_started.rst
+++ b/docs/source/intro/getting_started.rst
@@ -13,10 +13,10 @@ First Audible device
 ====================
 
 Before you can communicate with the non-publicly Audible Api, you need to
-authorize (login) yourself to Audible with your Audible username or Amazon
-account and register a new "virtual" Audible device. Please make sure to
-select the correct Audible marketplace. An overview about all known Audible
-marketplaces and associated country codes be found at :ref:`country_codes`.
+authorize (login) yourself to Amazon (or Audible) and register a new "virtual"
+Audible device. Please make sure to select the correct Audible marketplace.
+An overview about all known Audible marketplaces and associated country codes
+be found at :ref:`country_codes`.
 
 .. code-block::
 
@@ -30,7 +30,7 @@ marketplaces and associated country codes be found at :ref:`country_codes`.
        with_username=False
    )
    
-   # Save credendtials to file
+   # Save credentials to file
    auth.to_file(FILENAME)
 
 .. important::
@@ -42,11 +42,12 @@ marketplaces and associated country codes be found at :ref:`country_codes`.
 .. note::
 
    If you have activated 2-factor-authentication for your Amazon account, you
-   can append the current OTP to the password.
+   can append the current OTP to your password. This eliminates the need for a
+   new OTP prompt.
 
 .. note::
 
-   Set `with_username=True` to login with your Audible username (for US, UK or
+   Set `with_username=True` to login with your pre-Amazon account (for US, UK or
    DE marketplace only).
 
 .. note::
@@ -76,8 +77,8 @@ your first API call. To fetch and print out all books from your Audible library
 
 .. note::
 
-   The information provided by the API depends on the requested `response_groups`.
-   The response from the example above are very minimized. Please take a look at
+   The information returned by the API depends on the requested `response_groups`.
+   The response for the example above are very minimized. Please take a look at
    :http:get:`/1.0/library` for all known `response_groups` and other parameter
    for the library endpoint.
 

--- a/docs/source/intro/install.rst
+++ b/docs/source/intro/install.rst
@@ -30,7 +30,7 @@ development version::
     cd Audible
     pip install .
 
-Alternatively, install directly from the GitHub repository::
+Alternatively, install it directly from the GitHub repository::
 
     pip install git+https://github.com/mkb79/audible.git
 

--- a/docs/source/misc/advanced.rst
+++ b/docs/source/misc/advanced.rst
@@ -7,16 +7,28 @@ Client classes
 
 Here are some information about the ``Client`` and  the ``AsyncClient`` classes.
 
-Both client classes have the following methods to send requests 
+Instantiate a client
+--------------------
+
+A client needs at least an :class:`audible.Authenticator` at instantiation. The
+following args and kwargs can be passed to the client instantiation:
+
+* country_code (overrides the country code set in :class:`audible.Authenticator`)
+* headers (will be bypassed to the underlying httpx client)
+* timeout (will be bypassed to the underlying httpx client)
+* response_callback (custom response preparation - read more below)
+* all other kwargs (will be bypassed to the underlying httpx client)
+
+Make API requests
+-----------------
+
+Both client classes have the following methods to send requests
 to the external API:
 
 - get
 - post
 - delete
-- patch
-
-Make API requests
------------------
+- put
 
 The external Audible API offers currently two API versions, `0.0` and 
 `1.0`. The Client use the `1.0` by default. So both terms are equal::
@@ -24,7 +36,7 @@ The external Audible API offers currently two API versions, `0.0` and
    resp = client.get("library")
    resp = client.get("1.0/library")
 
-Each query parameter can be written as a separat keyword argument or you can
+Each query parameter can be written as a separate keyword argument or you can
 merge them as a dict to the `params` keyword. So both terms are equal::
 
    resp = client.get("library", response_groups="...", num_results=20)
@@ -51,6 +63,27 @@ and output them as a Python dict.
 .. note::
 
    For all known API endpoints take a look at :ref:`api_endpoints`.
+
+Client responses
+----------------
+
+.. versionadded:: v0.8.0
+
+   The ``response_callback`` kwarg to client __init__, get, post, delete and put methods.
+
+By default requesting the API with the client get, post, delete and put methods
+will call :func:`audible.client.raise_for_status` and try to convert
+the response with :func:`audible.client.convert_response_content` to a Python dict,
+which is finally returned.
+
+If you want to implement your own response preparation, you can do::
+
+   def own_response_callback(resp):
+       return resp
+
+   client = audible.Client(auth=..., response_callback=own_response_callback)
+
+This will return the unprepared response (include headers).
 
 Show/Change Marketplace
 -----------------------

--- a/docs/source/misc/load_save.rst
+++ b/docs/source/misc/load_save.rst
@@ -80,10 +80,15 @@ The following data will be stored:
 - device_info data
 - customer_info data
 - activation_bytes
+- with_username (``True`` for pre-Amazon accounts else ``False``)
 
 .. versionadded:: 0.5.1
 
    Stores ``activation_bytes`` to file (if they where fetched before).
+
+.. versionadded:: v0.8.0
+
+   The ``with_username`` value
 
 Advanced use of encryption/decryption
 =====================================
@@ -135,3 +140,4 @@ unencrypted. If the `Authenticator` can't load your data, you can try::
        decrypted_file=FILENAME,
        password=PASSWORD_FOR_ENCRYPTED_FILE
    )
+

--- a/src/audible/_logging.py
+++ b/src/audible/_logging.py
@@ -64,4 +64,3 @@ class AudibleLogHelper:
 
 
 log_helper = AudibleLogHelper()
-

--- a/src/audible/_version.py
+++ b/src/audible/_version.py
@@ -2,7 +2,7 @@ __title__ = "audible"
 __description__ = "A(Sync) Interface for internal Audible API written in " \
                   "pure Python."
 __url__ = "https://github.com/mkb79/audible"
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 __author__ = "mkb79"
 __author_email__ = "mkb79@hackitall.de"
 __license__ = "AGPL"

--- a/src/audible/_version.py
+++ b/src/audible/_version.py
@@ -2,7 +2,7 @@ __title__ = "audible"
 __description__ = "A(Sync) Interface for internal Audible API written in " \
                   "pure Python."
 __url__ = "https://github.com/mkb79/audible"
-__version__ = "0.8.0dev1"
+__version__ = "0.8.0dev2"
 __author__ = "mkb79"
 __author_email__ = "mkb79@hackitall.de"
 __license__ = "AGPL"

--- a/src/audible/_version.py
+++ b/src/audible/_version.py
@@ -2,7 +2,7 @@ __title__ = "audible"
 __description__ = "A(Sync) Interface for internal Audible API written in " \
                   "pure Python."
 __url__ = "https://github.com/mkb79/audible"
-__version__ = "0.7.2"
+__version__ = "0.8.0dev1"
 __author__ = "mkb79"
 __author_email__ = "mkb79@hackitall.de"
 __license__ = "AGPL"

--- a/src/audible/activation_bytes.py
+++ b/src/audible/activation_bytes.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 def get_player_id() -> str:
     """Build a software player Id."""
 
-    player_id = base64.encodebytes(hashlib.sha1(b"").digest()).rstrip()
+    player_id = base64.encodebytes(hashlib.sha1(b"").digest()).rstrip()  # noqa
     return player_id.decode("ascii")
 
 
@@ -168,7 +168,9 @@ def get_activation_bytes(
     else:
         raise AuthFlowError("No valid auth mode to fetch activation bytes.")
 
-    pathlib.Path(filename).write_bytes(activation) if filename else ""
+    if filename:
+        pathlib.Path(filename).write_bytes(activation)
+
     if extract:
         activation = extract_activation_bytes(activation)
 

--- a/src/audible/activation_bytes.py
+++ b/src/audible/activation_bytes.py
@@ -173,4 +173,3 @@ def get_activation_bytes(
         activation = extract_activation_bytes(activation)
 
     return activation
-

--- a/src/audible/aescipher.py
+++ b/src/audible/aescipher.py
@@ -462,4 +462,3 @@ def decrypt_voucher_from_licenserequest(
         asin=asin,
         voucher=encrypted_voucher
     )
-

--- a/src/audible/auth.py
+++ b/src/audible/auth.py
@@ -258,7 +258,7 @@ class Authenticator(httpx.Auth):
     refresh_token: Optional[str] = None
     store_authentication_cookie: Optional[Dict] = None
     website_cookies: Optional[Dict] = None
-    with_username: Optional[bool] = None
+    with_username: Optional[bool] = False
     requires_request_body: bool = True
     _forbid_new_attrs: bool = True
     _apply_test_convert: bool = True
@@ -316,8 +316,6 @@ class Authenticator(httpx.Auth):
 
         if "login_cookies" in data:
             auth.website_cookies = data.pop("login_cookies")
-
-        data.setdefault("with_username", False)
 
         auth._update_attrs(**data)
 
@@ -387,8 +385,6 @@ class Authenticator(httpx.Auth):
         # old names must be adjusted
         if "login_cookies" in json_data:
             auth.website_cookies = json_data.pop("login_cookies")
-
-        json_data.setdefault("with_username", False)
 
         auth._update_attrs(**json_data)
 

--- a/src/audible/auth.py
+++ b/src/audible/auth.py
@@ -214,6 +214,18 @@ class Authenticator(httpx.Auth):
         A new class instance have to be instantiate with
         :meth:`Authenticator.from_login` or :meth:`Authenticator.from_file`.
 
+    .. versionadded:: v0.8
+           The with_username attribute.
+
+    Note:
+        Auth data saved with v0.8 or later 
+        can not be loaded with versions less than v0.8!
+        If an auth file for an pre-Amazon account (with_username=True) was 
+        created with v0.7.1 or v0.7.2 set `auth.with_username` to `True` and 
+        save the data again. After this deregistration, refreshing access 
+        tokens and requesting cookies for another domain will work for 
+        pre-Amazon accounts.
+
     Attributes:
         access_token (:obj:`str`, :obj:`None`):
         activation_bytes (:obj:`str`, :obj:`None`):
@@ -305,6 +317,8 @@ class Authenticator(httpx.Auth):
         if "login_cookies" in data:
             auth.website_cookies = data.pop("login_cookies")
 
+        data.setdefault("with_username", False)
+
         auth._update_attrs(**data)
 
         logger.info(
@@ -373,6 +387,8 @@ class Authenticator(httpx.Auth):
         # old names must be adjusted
         if "login_cookies" in json_data:
             auth.website_cookies = json_data.pop("login_cookies")
+
+        json_data.setdefault("with_username", False)
 
         auth._update_attrs(**json_data)
 

--- a/src/audible/client.py
+++ b/src/audible/client.py
@@ -140,16 +140,17 @@ class Client:
         return user_profile["name"]
 
     def _prepare_api_path(self, path: str) -> httpx.URL:
+        if httpx.URL(path).is_absolute_url:
+            return httpx.URL(path)
+
         if path.startswith("/"):
             path = path[1:]
 
-        if path.startswith(self._API_VERSION) or path.startswith("0.0"):
-            pass
-        else:
+        if not (path.startswith(self._API_VERSION) or path.startswith("0.0")):
             path = "/".join((self._API_VERSION, path))
 
-        path = "/" + path
-        return self._api_url.copy_with(path=path)
+        path = ("/" + path).encode()
+        return self._api_url.copy_with(raw_path=path)
 
     def _request(
             self,

--- a/src/audible/exceptions.py
+++ b/src/audible/exceptions.py
@@ -80,4 +80,3 @@ class NoRefreshToken(Exception):
 
 class FileEncryptionError(Exception):
     """Raised if something is wrong with file encryption"""
-

--- a/src/audible/localization.py
+++ b/src/audible/localization.py
@@ -166,4 +166,3 @@ class Locale:
     @property
     def market_place_id(self) -> str:
         return self._market_place_id
-

--- a/src/audible/login.py
+++ b/src/audible/login.py
@@ -97,7 +97,7 @@ def default_login_url_callback(url: str) -> str:
             browser.close()
         return response_url
 
-    print("Please copy the following url and insert it in a webbrowser of "
+    print("Please copy the following url and insert it in a web browser of "
           "your choice:")
     print("\n" + url + "\n")
     print("Now you have to login with your Amazon credentials. After submit "

--- a/src/audible/register.py
+++ b/src/audible/register.py
@@ -62,11 +62,12 @@ def register(
         "requested_extensions": ["device_info", "customer_info"]
     }
 
-    reg_domain = f"amazon.{domain}"
-    if with_username:
-        reg_domain = f"audible.{domain}"
+    target_domain = "audible" if with_username else "amazon"
 
-    resp = httpx.post(f"https://api.{reg_domain}/auth/register", json=body)
+    resp = httpx.post(
+        f"https://api.{target_domain}.{domain}/auth/register",
+        json=body
+    )
 
     resp_json = resp.json()
     if resp.status_code != 200:
@@ -105,7 +106,10 @@ def register(
 
 
 def deregister(
-        access_token: str, domain: str, deregister_all: bool = False
+        access_token: str,
+        domain: str,
+        deregister_all: bool = False,
+        with_username: bool = False
 ) -> Dict[str, Any]:
     """Deregister a previous registered Audible device.
     
@@ -118,16 +122,22 @@ def deregister(
             which you want to deregister.
         domain: The top level domain of the requested Amazon server (e.g. com).
         deregister_all: If ``True``, deregister all Audible devices on Amazon.
+        with_username: If ``True`` uses `audible` domain instead of `amazon`.
 
     Returns:
         The response for the deregister request. Contains errors, if some occurs.
+
+    .. versionadded:: v0.8
+           The with_username argument
     """
 
     body = {"deregister_all_existing_accounts": deregister_all}
     headers = {"Authorization": f"Bearer {access_token}"}
 
+    target_domain = "audible" if with_username else "amazon"
+
     resp = httpx.post(
-        f"https://api.amazon.{domain}/auth/deregister",
+        f"https://api.{target_domain}.{domain}/auth/deregister",
         json=body,
         headers=headers
     )

--- a/src/audible/utils.py
+++ b/src/audible/utils.py
@@ -150,4 +150,3 @@ class ElapsedTime:
 
     def __call__(self):
         return time.time() - self.start_time
-


### PR DESCRIPTION
# Added

- full support of pre-Amazon accounts (e.g. refresh access token, deregister device)
- `Client` and `AsynClient` now accepts session kwargs which are bypassed to the underlying httpx Client
- a `respone_callback` can now be set to `Client` and `AsyncClient` class to allow custom preparation of response output

# Changed

- rename (and rework) `Client._split_kwargs` to `Client._prepare_params`