### PR TITLE
remove `pdf_url`, add `rights`, `customer_rights` `product_details`

### DIFF
--- a/docs/source/misc/external_api.rst
+++ b/docs/source/misc/external_api.rst
@@ -207,7 +207,7 @@ Products
    :type asin: string
    :query image_dpi:
    :query image_sizes:
-   :query response_groups: [contributors, media, price, product_attrs, product_desc, product_extended_attrs, product_plan_details, product_plans, rating, sample, sku, series, reviews, relationships, review_attrs, category_ladders, claim_code_url, provided_review, rights, customer_rights]
+   :query response_groups: [contributors, media, price, product_attrs, product_desc, product_details, product_extended_attrs, product_plan_details, product_plans, rating, sample, sku, series, reviews, relationships, review_attrs, category_ladders, claim_code_url, provided_review, rights, customer_rights]
    :query reviews_num_results: \\d+ (max: 10)
    :query reviews_sort_by: [MostHelpful, MostRecent]
    :query asins:

--- a/docs/source/misc/external_api.rst
+++ b/docs/source/misc/external_api.rst
@@ -207,7 +207,7 @@ Products
    :type asin: string
    :query image_dpi:
    :query image_sizes:
-   :query response_groups: [contributors, media, price, product_attrs, product_desc, product_extended_attrs, product_plan_details, product_plans, rating, sample, sku, series, reviews, relationships, review_attrs, category_ladders, claim_code_url, pdf_url, provided_review]
+   :query response_groups: [contributors, media, price, product_attrs, product_desc, product_extended_attrs, product_plan_details, product_plans, rating, sample, sku, series, reviews, relationships, review_attrs, category_ladders, claim_code_url, provided_review, rights, customer_rights]
    :query reviews_num_results: \\d+ (max: 10)
    :query reviews_sort_by: [MostHelpful, MostRecent]
    :query asins:


### PR DESCRIPTION
updated response groups for `/1.0/catalog/products/(string:asin)`
`pdf_url` is unsupported  now:
```json
"message": "Invalid response group(s) requested: pdf_url"
```

`rights` returns distribution countries, and `customer_rights` includes everything from `rights` plus more. `product_details` is the same as in the library endpoint.

Samples:

```json
{
    "product": {
        "asin": "B017V4IM1G",
        "distribution_rights_region": [
            "AS",
            "PR",
            "MP",
            "VI",
            "PW",
            "PH",
            "UM",
            "MH",
            "CA",
            "GU",
            "US"
        ],
        "is_world_rights": false,
        "sku": "BK_POTR_000001",
        "sku_lite": "BK_POTR_000001"
    },
    "response_groups": [
        "always-returned",
        "rights"
    ]
}
```

```json
{
    "product": {
        "asin": "B017V4IM1G",
        "available_codecs": [
            {
                "enhanced_codec": "LC_32_22050_stereo",
                "format": "Enhanced",
                "is_kindle_enhanced": true,
                "name": "aax_22_32"
            },
            {
                "enhanced_codec": "LC_128_44100_stereo",
                "format": "Enhanced",
                "is_kindle_enhanced": true,
                "name": "aax_44_128"
            },
            {
                "enhanced_codec": "LC_64_22050_stereo",
                "format": "Enhanced",
                "is_kindle_enhanced": true,
                "name": "aax_22_64"
            },
            {
                "enhanced_codec": "LC_64_44100_stereo",
                "format": "Enhanced",
                "is_kindle_enhanced": true,
                "name": "aax_44_64"
            },
            {
                "enhanced_codec": "mp42264",
                "format": "Enhanced",
                "is_kindle_enhanced": true,
                "name": "mp4_22_64"
            },
            {
                "enhanced_codec": "mp444128",
                "format": "Enhanced",
                "is_kindle_enhanced": true,
                "name": "mp4_44_128"
            },
            {
                "enhanced_codec": "mp44464",
                "format": "Enhanced",
                "is_kindle_enhanced": true,
                "name": "mp4_44_64"
            },
            {
                "enhanced_codec": "mp42232",
                "format": "Enhanced",
                "is_kindle_enhanced": true,
                "name": "mp4_22_32"
            },
            {
                "enhanced_codec": "aax",
                "format": "Enhanced",
                "is_kindle_enhanced": false,
                "name": "aax"
            }
        ],
        "content_delivery_type": "SinglePartBook",
        "content_type": "Product",
        "distribution_rights_region": [
            "AS",
            "PR",
            "MP",
            "VI",
            "PW",
            "PH",
            "UM",
            "MH",
            "CA",
            "GU",
            "US"
        ],
        "format_type": "unabridged",
        "has_children": false,
        "is_adult_product": false,
        "is_buyable": true,
        "is_listenable": true,
        "is_preorderable": false,
        "is_purchasability_suppressed": false,
        "is_vvab": false,
        "is_world_rights": false,
        "issue_date": "2015-11-20",
        "language": "english",
        "merchandising_summary": "<p>Harry Potter has never even heard of Hogwarts when the letters start dropping on the doormat at number four, Privet Drive. Addressed in green ink on yellowish parchment with a purple seal, they are swiftly confiscated by his grisly aunt and uncle....</p>",
        "plans": [
            {
                "end_date": "2018-11-17T00:00:00.000-00:00",
                "plan_name": "Radio",
                "start_date": "2018-11-16T00:00:00.000-00:00"
            }
        ],
        "preorder_release_date": "2015-11-20T08:00:00Z",
        "publication_datetime": "2015-11-20T08:00:00Z",
        "publication_name": "Harry Potter",
        "release_date": "2015-11-20",
        "runtime_length_min": 498,
        "sku": "BK_POTR_000001",
        "sku_lite": "BK_POTR_000001",
        "thesaurus_subject_keywords": [
            "literature-and-fiction"
        ]
    },
    "response_groups": [
        "customer_rights",
        "always-returned"
    ]
}
```

```json
{
    "product": {
        "asin": "B0C28X89RN",
        "copyright": "©2023 Jack Bryce (P)2023 Royal Guard Publishing LLC",
        "date_first_available": "2023-05-03",
        "extended_product_description": "<p>With fall on the way, James is working hard to prepare his cabin for the colder seasons. Cutting wood, bringing in the last harvest, getting supplies.... Even with magic, he has his work cut out for him.</p>",
        "is_pdf_url_available": false,
        "merchandising_description": "",
        "platinum_keywords": [
            "Erotica"
        ],
        "product_site_launch_date": "2023-04-19T07:00:00Z",
        "read_along_support": "true",
        "sku": "BK_ACX0_348775",
        "sku_lite": "BK_ACX0_348775"
    },
    "response_groups": [
        "always-returned",
        "product_details"
    ]
}
```