### PR TITLE
Update datetime functions to use timezone awareness

### DIFF
--- a/src/audible/register.py
+++ b/src/audible/register.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import httpx
@@ -80,7 +80,7 @@ def register(
     access_token = tokens["bearer"]["access_token"]
     refresh_token = tokens["bearer"]["refresh_token"]
     expires_s = int(tokens["bearer"]["expires_in"])
-    expires = (datetime.utcnow() + timedelta(seconds=expires_s)).timestamp()
+    expires = (datetime.now(timezone.utc) + timedelta(seconds=expires_s)).timestamp()
 
     extensions = success_response["extensions"]
     device_info = extensions["device_info"]


### PR DESCRIPTION
The commit updates all datetime.utcnow() to datetime.now(timezone.utc) for accurate timezone-aware handling within the 'audible' module. This is crucial to avoid issues related to DST and timezones disparities. By using details of the timezone offset, accurate comparisons and calculations are assured.