### PR TITLE
Update pre-commit hook stages for consistency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         entry: end-of-file-fixer
         language: system
         types: [text]
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: ruff-check
         name: ruff check
         entry: ruff check
@@ -44,7 +44,7 @@ repos:
         entry: trailing-whitespace-fixer
         language: system
         types: [text]
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.3
     hooks:


### PR DESCRIPTION
Replaced "commit" and "push" stages with "pre-commit" and "pre-push" in `.pre-commit-config.yaml` to align with standard naming conventions. This ensures better clarity and consistency across hook configurations.