### PR TITLE
docs: add `goodreads_ratings` response group to `catalog/products/ASIN`

### DIFF
--- a/docs/source/misc/external_api.rst
+++ b/docs/source/misc/external_api.rst
@@ -207,7 +207,7 @@ Products
    :type asin: string
    :query image_dpi:
    :query image_sizes:
-   :query response_groups: [contributors, media, price, product_attrs, product_desc, product_details, product_extended_attrs, product_plan_details, product_plans, rating, sample, sku, series, reviews, relationships, review_attrs, category_ladders, claim_code_url, provided_review, rights, customer_rights]
+   :query response_groups: [contributors, media, price, product_attrs, product_desc, product_details, product_extended_attrs, product_plan_details, product_plans, rating, sample, sku, series, reviews, relationships, review_attrs, category_ladders, claim_code_url, provided_review, rights, customer_rights, goodreads_ratings]
    :query reviews_num_results: \\d+ (max: 10)
    :query reviews_sort_by: [MostHelpful, MostRecent]
    :query asins:


### PR DESCRIPTION
Provides aggregate Goodreads data:
```
"goodreads_ratings": {
            "count": "225 ratings",
            "rating": "4.6 on",
            "rating_num": 4.599999904632568
        },
```

I stumbled upon this while looking for a Goodreads ID somewhere in the API, but so far, I have only found this link to it.