### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   labeler:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository


### PR DESCRIPTION
Potential fix for [https://github.com/mkb79/Audible/security/code-scanning/7](https://github.com/mkb79/Audible/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the workflow. Based on the functionality of the `crazy-max/ghaction-github-labeler` action, it requires `contents: read` to access repository contents and `pull-requests: write` to manage labels on pull requests. We will add these permissions at the job level to limit their scope to the `labeler` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
