### PR TITLE
security: add explicit permissions to tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.13"
 


### PR DESCRIPTION
## Summary

Adds explicit `permissions` declaration to the tests workflow following the principle of least privilege.

## Changes

- Added `permissions: contents: read` to `.github/workflows/tests.yml`
- Restricts workflow permissions to read-only access to repository contents

## Security Benefits

- **Principle of Least Privilege**: The workflow now explicitly declares it only needs read access to the repository
- **Defense in Depth**: Prevents potential privilege escalation if the workflow or its dependencies are compromised
- **Best Practice Alignment**: Matches permission patterns used in other workflows (`claude-code-review.yml`, `labeler.yml`)

## Testing

The workflow only needs:
- ✅ Read access to checkout the repository
- ✅ Read access to run tests
- ✅ Standard artifact upload/download capabilities (included in default permissions)

## Related

This change is part of a security audit of all GitHub Actions workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)