### PR TITLE
chore: exclude renovate.json5 from prettier hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
     rev: v3.0.3
     hooks:
       - id: prettier
+        exclude: '^renovate\.json5$'
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
     rev: 0.7.6


### PR DESCRIPTION
## Summary

- Excludes `renovate.json5` from the prettier pre-commit hook
- Prevents prettier from reformatting Renovate's configuration file

## Motivation

Renovate uses JSON5 format with specific formatting conventions for its configuration file. The prettier hook was attempting to reformat this file, potentially breaking Renovate's expected format or causing unnecessary formatting changes in version control.

## Changes

- Added `exclude: '^renovate\.json5$'` pattern to the prettier hook in `.pre-commit-config.yaml`

## Testing

✅ Ran `uv run nox -s pre-commit` successfully - all hooks passed
✅ Verified `renovate.json5` remains unchanged after pre-commit run
✅ Confirmed no other files are affected by this exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)