### PR TITLE
fix(workflow): add pull-requests write permission for Claude reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write # Required for gh pr comment
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Problem

The Claude Code Review workflow was successfully analyzing PRs but **could not post comments** because it lacked the necessary GitHub permissions.

### Root Cause

The workflow configuration had two conflicting settings:

1. **Allowed tool**: `gh pr comment:*` was explicitly allowed in `claude_args`
2. **GitHub permission**: Only `pull-requests: read` was granted

This caused Claude to create comprehensive reviews but fail when trying to post them with `gh pr comment`.

## Solution

Changed GitHub workflow permissions from:
```yaml
permissions:
  pull-requests: read  # ❌ Only read access
```

To:
```yaml
permissions:
  pull-requests: write  # ✅ Can now post comments
```

## Evidence

From workflow run [#18850594061](https://github.com/mkb79/Audible/actions/runs/18850594061):

```
{"type":"tool_result", "content": "This Bash command contains multiple operations. 
The following parts require approval: gh pr comment 822 --body ...", "is_error": true}
```

Claude successfully generated a comprehensive review but couldn't post it due to missing write permission.

## Testing

After merging, the workflow will be able to:
- ✅ Analyze PRs (already working)
- ✅ Post review comments (will be fixed)

## Changes

- Changed `pull-requests: read` → `pull-requests: write`
- Added inline comment explaining the permission requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)