### PR TITLE
feat(auth): switch to x-amz-access-token and guard async token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- Asynchronous access token refresh for `AsyncClient`. `Authenticator.async_auth_flow` and the new `async_refresh_access_token` refresh the token without blocking the event loop, guarded by an `asyncio.Lock` (bound to the running event loop) so that multiple concurrent requests trigger only a single refresh. The synchronous `refresh_access_token` is likewise guarded by a `threading.Lock`.
+
+### Changed
+
+- API requests now authenticate with the `x-amz-access-token` header instead of the legacy `Authorization: Bearer` scheme, matching the current Audible API (see [#832](https://github.com/mkb79/Audible/issues/832)). Header construction is centralized in the new `audible.utils.build_access_token_header` helper. The obsolete `client-id: 0` header is no longer sent with bearer auth.
+
 ## [0.11.0] - 2026-07-20
 
 ### Added

--- a/src/audible/auth.py
+++ b/src/audible/auth.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
-from collections.abc import Callable, Generator, Iterator
+import threading
+from collections.abc import AsyncGenerator, Callable, Generator, Iterator
 from datetime import UTC, datetime, timedelta
 from typing import (
     TYPE_CHECKING,
@@ -23,7 +25,7 @@ from .json_provider import get_json_provider
 from .login import external_login, login
 from .register import deregister as deregister_
 from .register import register as register_
-from .utils import test_convert
+from .utils import build_access_token_header, test_convert
 
 
 if TYPE_CHECKING:
@@ -35,6 +37,28 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger("audible.auth")
+
+
+def _refresh_token_request_body(refresh_token: str) -> dict[str, str]:
+    """Build the request body for an access token refresh."""
+    return {
+        "app_name": "Audible",
+        "app_version": "3.56.2",
+        "source_token": refresh_token,
+        "requested_token_type": "access_token",
+        "source_token_type": "refresh_token",
+    }
+
+
+def _parse_refresh_token_response(resp: httpx.Response) -> dict[str, Any]:
+    """Parse an ``/auth/token`` response into access token and expiry."""
+    resp.raise_for_status()
+    resp_dict = resp.json()
+
+    expires_in_sec = int(resp_dict["expires_in"])
+    expires = (datetime.now(UTC) + timedelta(seconds=expires_in_sec)).timestamp()
+
+    return {"access_token": resp_dict["access_token"], "expires": expires}
 
 
 def refresh_access_token(
@@ -58,24 +82,43 @@ def refresh_access_token(
     .. versionadded:: v0.8
         The with_username argument
     """
-    body = {
-        "app_name": "Audible",
-        "app_version": "3.56.2",
-        "source_token": refresh_token,
-        "requested_token_type": "access_token",
-        "source_token_type": "refresh_token",
-    }
-
     target_domain = "audible" if with_username else "amazon"
+    url = f"https://api.{target_domain}.{domain}/auth/token"
 
-    resp = httpx.post(f"https://api.{target_domain}.{domain}/auth/token", data=body)
-    resp.raise_for_status()
-    resp_dict = resp.json()
+    resp = httpx.post(url, data=_refresh_token_request_body(refresh_token))
 
-    expires_in_sec = int(resp_dict["expires_in"])
-    expires = (datetime.now(UTC) + timedelta(seconds=expires_in_sec)).timestamp()
+    return _parse_refresh_token_response(resp)
 
-    return {"access_token": resp_dict["access_token"], "expires": expires}
+
+async def async_refresh_access_token(
+    refresh_token: str, domain: str, with_username: bool = False
+) -> dict[str, Any]:
+    """Refreshes an access token asynchronously.
+
+    Async counterpart of :func:`refresh_access_token`. Performs the token
+    request without blocking the event loop, so it can be awaited from an
+    :class:`~audible.client.AsyncClient` request.
+
+    Args:
+        refresh_token: The refresh token obtained after a device
+            registration.
+        domain: The top level domain of the requested Amazon server
+            (e.g. com).
+        with_username: If ``True`` uses `audible` domain instead of `amazon`.
+
+    Returns:
+        A dict with the new access token and expiration timestamp.
+
+    Note:
+        The new access token is valid for 60 minutes.
+    """
+    target_domain = "audible" if with_username else "amazon"
+    url = f"https://api.{target_domain}.{domain}/auth/token"
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(url, data=_refresh_token_request_body(refresh_token))
+
+    return _parse_refresh_token_response(resp)
 
 
 def refresh_website_cookies(
@@ -139,7 +182,7 @@ def user_profile(access_token: str, domain: str) -> dict[str, Any]:
     Raises:
         Exception: If the user profile is malformed
     """
-    headers = {"Authorization": f"Bearer {access_token}"}
+    headers = build_access_token_header(access_token)
 
     resp = httpx.get(f"https://api.amazon.{domain}/user/profile", headers=headers)
     resp.raise_for_status()
@@ -165,7 +208,7 @@ def user_profile_audible(access_token: str, domain: str) -> dict[str, Any]:
     Raises:
         Exception: If the user profile is malformed
     """
-    headers = {"Authorization": f"Bearer {access_token}"}
+    headers = build_access_token_header(access_token)
 
     resp = httpx.get(f"https://api.audible.{domain}/user/profile", headers=headers)
     resp.raise_for_status()
@@ -282,6 +325,9 @@ class Authenticator(httpx.Auth):
     _apply_test_convert: bool = True
     _cached_rsa_key: Any = None
     _crypto_provider: CryptoProvider | None = None
+    _refresh_lock: Any = None
+    _async_refresh_lock: asyncio.Lock | None = None
+    _async_refresh_lock_loop: Any = None
 
     def __init__(
         self,
@@ -289,6 +335,12 @@ class Authenticator(httpx.Auth):
         crypto_provider: CryptoProvider | type[CryptoProvider] | None = None,
     ) -> None:
         super().__init__()
+
+        # Serialize token refreshes so concurrent requests don't each trigger a
+        # refresh. The threading lock guards the blocking (sync) refresh; the
+        # asyncio lock is created lazily per running event loop, see
+        # ``_get_async_refresh_lock``.
+        self._refresh_lock = threading.Lock()
 
         if crypto_provider is not None:
             self._crypto_provider = get_crypto_providers(crypto_provider)
@@ -559,6 +611,26 @@ class Authenticator(httpx.Auth):
 
         return auth
 
+    def _select_auth_mode(self) -> str:
+        """Return the auth mode to apply, preferring signing over bearer.
+
+        Returns:
+            The name of the auth mode to apply (``"signing"`` or ``"bearer"``).
+
+        Raises:
+            AuthFlowError: If neither signing nor bearer auth is available.
+        """
+        available_modes = self.available_auth_modes
+
+        if "signing" in available_modes:
+            return "signing"
+        if "bearer" in available_modes:
+            return "bearer"
+
+        message = "signing or bearer auth flow are not available."
+        logger.critical(message)
+        raise AuthFlowError(message)
+
     def auth_flow(
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
@@ -569,20 +641,40 @@ class Authenticator(httpx.Auth):
 
         Yields:
             httpx.Request: The authenticated request with signed headers.
-
-        Raises:
-            AuthFlowError: If no auth flow is available.
         """
-        available_modes = self.available_auth_modes
-
-        if "signing" in available_modes:
+        if self._select_auth_mode() == "signing":
             self._apply_signing_auth_flow(request)
-        elif "bearer" in available_modes:
-            self._apply_bearer_auth_flow(request)
         else:
-            message = "signing or bearer auth flow are not available."
-            logger.critical(message)
-            raise AuthFlowError(message)
+            self._apply_bearer_auth_flow(request)
+
+        yield request
+
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        """Async auth flow executed on every request by :mod:`httpx`.
+
+        Async counterpart of :meth:`auth_flow` used by
+        :class:`~audible.client.AsyncClient`. It mirrors the sync flow but
+        refreshes the access token asynchronously and guards the refresh with
+        an :class:`asyncio.Lock`, so multiple concurrent requests never trigger
+        more than one refresh (see :meth:`async_refresh_access_token`).
+
+        Args:
+            request: The request made by ``httpx``.
+
+        Yields:
+            httpx.Request: The authenticated request with signed headers.
+        """
+        # ``requires_request_body`` is True, so make the body available for the
+        # signing flow (httpx' default async flow does the same before signing).
+        if self.requires_request_body:
+            await request.aread()
+
+        if self._select_auth_mode() == "signing":
+            self._apply_signing_auth_flow(request)
+        else:
+            await self._async_apply_bearer_auth_flow(request)
 
         yield request
 
@@ -619,8 +711,17 @@ class Authenticator(httpx.Auth):
         if self.access_token is None:
             raise Exception("No access token found.")
 
-        headers = {"Authorization": "Bearer " + self.access_token, "client-id": "0"}
-        request.headers.update(headers)
+        request.headers.update(build_access_token_header(self.access_token))
+        logger.info("bearer auth flow applied to request")
+
+    async def _async_apply_bearer_auth_flow(self, request: httpx.Request) -> None:
+        if self.access_token_expired:
+            await self.async_refresh_access_token()
+
+        if self.access_token is None:
+            raise Exception("No access token found.")
+
+        request.headers.update(build_access_token_header(self.access_token))
         logger.info("bearer auth flow applied to request")
 
     def _apply_cookies_auth_flow(self, request: httpx.Request) -> None:
@@ -761,27 +862,83 @@ class Authenticator(httpx.Auth):
             with_username=self.with_username or False,
         )
 
+    def _get_async_refresh_lock(self) -> asyncio.Lock:
+        """Return an asyncio lock bound to the current running event loop.
+
+        The lock is created lazily and re-created when the running loop
+        changes, so a single Authenticator can be safely reused across
+        multiple event loops (e.g. successive ``asyncio.run`` calls). This
+        runs inside the event loop with no ``await`` between the check and the
+        assignment, so concurrent tasks cannot create competing locks.
+        """
+        loop = asyncio.get_running_loop()
+        lock = self._async_refresh_lock
+        if lock is None or self._async_refresh_lock_loop is not loop:
+            lock = asyncio.Lock()
+            self._async_refresh_lock = lock
+            self._async_refresh_lock_loop = loop
+        return lock
+
+    def _refresh_request_params(self) -> dict[str, Any]:
+        """Validate prerequisites and build the refresh request parameters."""
+        if self.refresh_token is None:
+            message = "No refresh token found. Can't refresh access token."
+            logger.critical(message)
+            raise NoRefreshToken(message)
+        if self.locale is None:
+            raise Exception("No locale found.")
+
+        return {
+            "refresh_token": self.refresh_token,
+            "domain": self.locale.domain,
+            "with_username": self.with_username or False,
+        }
+
     def refresh_access_token(self, force: bool = False) -> None:
-        if force or self.access_token_expired:
-            if self.refresh_token is None:
-                message = "No refresh token found. Can't refresh access token."
-                logger.critical(message)
-                raise NoRefreshToken(message)
-            if self.locale is None:
-                raise Exception("No locale found.")
-
-            refresh_data = refresh_access_token(
-                refresh_token=self.refresh_token,
-                domain=self.locale.domain,
-                with_username=self.with_username or False,
-            )
-
-            self._update_attrs(**refresh_data)
-        else:
+        if not force and not self.access_token_expired:
             logger.info(
                 "Access Token not expired. No refresh necessary. "
                 "To force refresh please use force=True"
             )
+            return
+
+        with self._refresh_lock:
+            # Re-check inside the lock: another thread may have refreshed the
+            # token while we were waiting to acquire the lock.
+            if not force and not self.access_token_expired:
+                return
+
+            refresh_data = refresh_access_token(**self._refresh_request_params())
+            self._update_attrs(**refresh_data)
+
+    async def async_refresh_access_token(self, force: bool = False) -> None:
+        """Refresh the access token asynchronously without blocking the loop.
+
+        Concurrent requests share a single refresh: the first task to find the
+        token expired performs the refresh while the others wait on the
+        :class:`asyncio.Lock` and then observe the freshly updated token,
+        instead of each firing its own refresh request.
+
+        Args:
+            force: If ``True`` refresh even if the current token is not expired.
+        """
+        if not force and not self.access_token_expired:
+            logger.info(
+                "Access Token not expired. No refresh necessary. "
+                "To force refresh please use force=True"
+            )
+            return
+
+        async with self._get_async_refresh_lock():
+            # Re-check inside the lock: another task may have refreshed the
+            # token while we were waiting to acquire the lock.
+            if not force and not self.access_token_expired:
+                return
+
+            refresh_data = await async_refresh_access_token(
+                **self._refresh_request_params()
+            )
+            self._update_attrs(**refresh_data)
 
     def set_website_cookies_for_country(self, country_code: str) -> None:
         cookies_domain = test_convert("locale", country_code).domain

--- a/src/audible/register.py
+++ b/src/audible/register.py
@@ -4,6 +4,7 @@ from typing import Any
 import httpx
 
 from .login import build_client_id
+from .utils import build_access_token_header
 
 
 def register(
@@ -134,7 +135,7 @@ def deregister(
            The with_username argument
     """
     body = {"deregister_all_existing_accounts": deregister_all}
-    headers = {"Authorization": f"Bearer {access_token}"}
+    headers = build_access_token_header(access_token)
 
     target_domain = "audible" if with_username else "amazon"
 

--- a/src/audible/utils.py
+++ b/src/audible/utils.py
@@ -12,6 +12,24 @@ from .localization import Locale
 logger = logging.getLogger("audible.utils")
 
 
+def build_access_token_header(access_token: str) -> dict[str, str]:
+    """Build the auth header used to authenticate with an access token.
+
+    Audible/Amazon expect the access token in the ``x-amz-access-token``
+    header (replacing the legacy ``Authorization: Bearer`` scheme).
+    Centralizing the header construction keeps every call site in sync when
+    the authentication scheme changes.
+
+    Args:
+        access_token: A valid access token obtained from a device
+            registration or a token refresh.
+
+    Returns:
+        A single-entry header mapping ready to merge into request headers.
+    """
+    return {"x-amz-access-token": access_token}
+
+
 def _check_website_cookies(value: dict[str, str]) -> None:
     if not isinstance(value, dict):
         raise TypeError(f"website_cookies: Expected dict, got {type(value).__name__}.")

--- a/tests/test_auth_access_token.py
+++ b/tests/test_auth_access_token.py
@@ -1,0 +1,272 @@
+"""Tests for x-amz-access-token bearer auth and race-safe token refresh."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+import audible.auth as auth_mod
+import audible.register as register_mod
+from audible import AsyncClient
+from audible.auth import Authenticator
+from audible.exceptions import AuthFlowError
+from audible.utils import build_access_token_header
+
+
+# Far-future / epoch timestamps to control token expiry deterministically.
+TOKEN_VALID = 9_999_999_999.0
+TOKEN_EXPIRED = 0.0
+
+NEW_ACCESS_TOKEN = "Atna|NEWTOKENForUnitTestingOnlyNotReal1234567890"  # noqa: S105
+
+
+def _bearer_auth(auth_fixture_data: dict[str, Any], *, expires: float) -> Authenticator:
+    """Build a fake-credential authenticator that selects bearer auth.
+
+    Args:
+        auth_fixture_data: The shared fake auth fixture data.
+        expires: The access token expiry timestamp to set.
+
+    Returns:
+        An authenticator with signing credentials removed so that
+        :meth:`Authenticator._select_auth_mode` picks ``"bearer"``.
+    """
+    auth = Authenticator.from_dict(auth_fixture_data)
+    auth.adp_token = None
+    auth.device_private_key = None
+    auth.website_cookies = None
+    auth.expires = expires
+    return auth
+
+
+async def _apply_async_auth_flow(auth: Authenticator, request: httpx.Request) -> None:
+    """Drive ``async_auth_flow`` once (apply auth) and close the generator."""
+    gen = auth.async_auth_flow(request)
+    await gen.__anext__()
+    await gen.aclose()
+
+
+def test_build_access_token_header() -> None:
+    """The helper builds the x-amz-access-token header, not Bearer."""
+    assert build_access_token_header("Atna|TOKEN") == {
+        "x-amz-access-token": "Atna|TOKEN"
+    }
+
+
+def test_sync_bearer_flow_sets_x_amz_access_token(
+    auth_fixture_data: dict[str, Any],
+) -> None:
+    """The sync bearer flow sends x-amz-access-token and drops client-id/Bearer."""
+    auth = _bearer_auth(auth_fixture_data, expires=TOKEN_VALID)
+    request = httpx.Request("GET", "https://api.audible.de/1.0/library")
+
+    auth._apply_bearer_auth_flow(request)
+
+    assert request.headers["x-amz-access-token"] == auth.access_token
+    assert "authorization" not in request.headers
+    assert "client-id" not in request.headers
+
+
+def test_async_bearer_flow_sets_x_amz_access_token(
+    auth_fixture_data: dict[str, Any],
+) -> None:
+    """The async bearer flow sends x-amz-access-token and drops client-id/Bearer."""
+    auth = _bearer_auth(auth_fixture_data, expires=TOKEN_VALID)
+    request = httpx.Request("GET", "https://api.audible.de/1.0/library")
+
+    asyncio.run(auth._async_apply_bearer_auth_flow(request))
+
+    assert request.headers["x-amz-access-token"] == auth.access_token
+    assert "authorization" not in request.headers
+    assert "client-id" not in request.headers
+
+
+def test_select_auth_mode_prefers_signing(
+    auth_fixture_data: dict[str, Any],
+) -> None:
+    """Signing is preferred over bearer when both are available."""
+    auth = Authenticator.from_dict(auth_fixture_data)
+
+    assert "signing" in auth.available_auth_modes
+    assert "bearer" in auth.available_auth_modes
+    assert auth._select_auth_mode() == "signing"
+
+
+def test_select_auth_mode_falls_back_to_bearer(
+    auth_fixture_data: dict[str, Any],
+) -> None:
+    """Bearer is selected once signing credentials are unavailable."""
+    auth = _bearer_auth(auth_fixture_data, expires=TOKEN_VALID)
+
+    assert auth.available_auth_modes == ["bearer"]
+    assert auth._select_auth_mode() == "bearer"
+
+
+def test_select_auth_mode_raises_without_modes(
+    auth_fixture_data: dict[str, Any],
+) -> None:
+    """No signing and no bearer credentials raise AuthFlowError."""
+    auth = _bearer_auth(auth_fixture_data, expires=TOKEN_VALID)
+    auth.access_token = None
+
+    with pytest.raises(AuthFlowError):
+        auth._select_auth_mode()
+
+
+def test_async_auth_flow_uses_signing_when_available(
+    auth_fixture_data: dict[str, Any],
+) -> None:
+    """A full auth file signs requests; x-amz-access-token is not used."""
+    auth = Authenticator.from_dict(auth_fixture_data)
+    request = httpx.Request("GET", "https://api.audible.de/1.0/library")
+
+    asyncio.run(_apply_async_auth_flow(auth, request))
+
+    assert "x-adp-token" in request.headers
+    assert "x-amz-access-token" not in request.headers
+
+
+def test_sync_refresh_skips_when_not_expired(
+    auth_fixture_data: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-expired token is not refreshed over the network."""
+    auth = _bearer_auth(auth_fixture_data, expires=TOKEN_VALID)
+    calls = 0
+
+    def fake_refresh(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {"access_token": NEW_ACCESS_TOKEN, "expires": TOKEN_VALID}
+
+    monkeypatch.setattr(auth_mod, "refresh_access_token", fake_refresh)
+
+    auth.refresh_access_token()
+
+    assert calls == 0
+
+
+def test_sync_refresh_runs_when_expired(
+    auth_fixture_data: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An expired token triggers exactly one sync refresh."""
+    auth = _bearer_auth(auth_fixture_data, expires=TOKEN_EXPIRED)
+    calls = 0
+
+    def fake_refresh(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {"access_token": NEW_ACCESS_TOKEN, "expires": TOKEN_VALID}
+
+    monkeypatch.setattr(auth_mod, "refresh_access_token", fake_refresh)
+
+    auth.refresh_access_token()
+
+    assert calls == 1
+    assert auth.access_token == NEW_ACCESS_TOKEN
+
+
+def test_async_refresh_coalesces_concurrent_requests(
+    auth_fixture_data: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ten concurrent expired-token requests trigger a single async refresh."""
+    auth = _bearer_auth(auth_fixture_data, expires=TOKEN_EXPIRED)
+    calls = 0
+
+    async def fake_refresh(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.02)  # widen the race window
+        return {"access_token": NEW_ACCESS_TOKEN, "expires": TOKEN_VALID}
+
+    monkeypatch.setattr(auth_mod, "async_refresh_access_token", fake_refresh)
+
+    async def drive() -> list[httpx.Request]:
+        requests = [
+            httpx.Request("GET", "https://api.audible.de/1.0/library")
+            for _ in range(10)
+        ]
+        await asyncio.gather(
+            *[auth._async_apply_bearer_auth_flow(req) for req in requests]
+        )
+        return requests
+
+    requests = asyncio.run(drive())
+
+    assert calls == 1
+    assert auth.access_token == NEW_ACCESS_TOKEN
+    assert all(
+        req.headers["x-amz-access-token"] == NEW_ACCESS_TOKEN for req in requests
+    )
+
+
+def test_async_refresh_lock_reused_across_event_loops(
+    auth_fixture_data: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same authenticator can refresh in successive asyncio.run() loops."""
+    auth = _bearer_auth(auth_fixture_data, expires=TOKEN_EXPIRED)
+
+    async def fake_refresh(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"access_token": NEW_ACCESS_TOKEN, "expires": TOKEN_EXPIRED}
+
+    monkeypatch.setattr(auth_mod, "async_refresh_access_token", fake_refresh)
+
+    # A lock bound to the first loop would raise "bound to a different loop".
+    asyncio.run(auth.async_refresh_access_token(force=True))
+    asyncio.run(auth.async_refresh_access_token(force=True))
+
+
+def test_asyncclient_concurrent_requests_single_refresh(
+    auth_fixture_data: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End to end: concurrent AsyncClient calls refresh once and send the token."""
+    auth = _bearer_auth(auth_fixture_data, expires=TOKEN_EXPIRED)
+    calls = 0
+
+    async def fake_refresh(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.02)
+        return {"access_token": NEW_ACCESS_TOKEN, "expires": TOKEN_VALID}
+
+    monkeypatch.setattr(auth_mod, "async_refresh_access_token", fake_refresh)
+
+    sent_tokens: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        sent_tokens.append(request.headers.get("x-amz-access-token"))
+        return httpx.Response(200, json={"items": []})
+
+    async def drive() -> None:
+        async with AsyncClient(
+            auth=auth, transport=httpx.MockTransport(handler)
+        ) as client:
+            await asyncio.gather(*[client.get("library") for _ in range(10)])
+
+    asyncio.run(drive())
+
+    assert calls == 1
+    assert sent_tokens == [NEW_ACCESS_TOKEN] * 10
+
+
+def test_deregister_sends_x_amz_access_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """register.deregister authenticates with x-amz-access-token, not Bearer."""
+    captured: dict[str, Any] = {}
+
+    def fake_post(
+        url: str, json: Any = None, headers: Any = None, **kwargs: Any
+    ) -> httpx.Response:
+        captured["headers"] = headers
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    result = register_mod.deregister("Atna|TOKEN", "de")
+
+    assert result == {"ok": True}
+    assert captured["headers"] == {"x-amz-access-token": "Atna|TOKEN"}
+    assert "Authorization" not in captured["headers"]


### PR DESCRIPTION
## Summary

Two related changes to `Authenticator` authentication:

### 1. `x-amz-access-token` instead of `Authorization: Bearer` (#832)
The current Audible API no longer accepts the legacy `Authorization: Bearer <access_token>` scheme; it expects the access token in the `x-amz-access-token` header. All call sites now build the header through a single helper `audible.utils.build_access_token_header`, so the auth scheme lives in one place:

- `auth.py`: `user_profile`, `user_profile_audible`, bearer auth flow
- `register.py`: `deregister`

### 2. Race-condition-safe async token refresh
Previously only `auth_flow` (a sync generator) was implemented, so the `AsyncClient` drove it via httpx's default `async_auth_flow`. With access-token auth, several concurrent async requests could each detect the expired token and fire their own refresh.

- `async_auth_flow` / `_async_apply_bearer_auth_flow`: async counterparts that apply auth without blocking the event loop (per httpx guidance to override `async_auth_flow` when the scheme does I/O or uses locks).
- `async_refresh_access_token` (module + method): non-blocking refresh via `httpx.AsyncClient`, guarded by a **loop-aware `asyncio.Lock`** with **double-checked expiry** — the first task refreshes, the rest observe the fresh token.
- Sync `refresh_access_token` guarded by a `threading.Lock` with the same double-checked pattern.
- `_select_auth_mode` helper shared by both flows (no dispatch duplication); shared refresh request-body / response-parsing helpers between sync and async.

## Notes
- Redirect behavior is unchanged: httpx follows redirects in a layer *inside* the auth layer, so the auth flow runs once and httpx copies the headers to each hop. The path-independent `x-amz-access-token` stays valid across hops (unlike a path-bound signature).
- The larger token-model change from #832 (`actor_access_token` / `actor_refresh_token`, new `/auth/token` request/response shape) is **out of scope** here — the refresh parsing is unchanged.

## Verification
- New `## [Unreleased]` entry in `CHANGELOG.md`.
- `uv run nox`: **16/16 sessions green** (pre-commit, safety, mypy 3.11–3.14, tests 3.11–3.14, typeguard, xdoctest 3.11–3.14, docs-build).
- Ad-hoc checks: 20 concurrent async requests with an expired token trigger exactly **one** refresh (also across multiple event loops); redirect hops carry `x-amz-access-token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)