### PR TITLE
fix(json): honor ensure_ascii in the orjson provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - API requests now authenticate with the `x-amz-access-token` header instead of the legacy `Authorization: Bearer` scheme, matching the current Audible API (see [#832](https://github.com/mkb79/Audible/issues/832)). Header construction is centralized in the new `audible.utils.build_access_token_header` helper. The obsolete `client-id: 0` header is no longer sent with bearer auth.
 
+### Fixed
+
+- `OrjsonProvider` now honors the `ensure_ascii` parameter. Non-ASCII characters were previously left unescaped, so the serialized output depended on which JSON library was installed.
+
 ## [0.11.0] - 2026-07-20
 
 ### Added

--- a/src/audible/json_provider/orjson_provider.py
+++ b/src/audible/json_provider/orjson_provider.py
@@ -14,12 +14,14 @@ This provider implements smart fallback logic:
 - indent=4 or other -> falls back to ujson/rapidjson/stdlib
 - separators specified -> falls back to stdlib
 - indent=2 or None -> uses native orjson (maximum performance)
+- ensure_ascii=True -> escapes orjson's output in place (no re-encode)
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 from .exceptions import JSONDecodeError, JSONEncodeError
@@ -39,6 +41,47 @@ except ImportError:
 
 
 logger = logging.getLogger("audible.json_provider.orjson")
+
+
+_NON_ASCII_PATTERN = re.compile(r"[^\x00-\x7f]")
+
+
+def _escape_match(match: re.Match[str]) -> str:
+    r"""Render a single non-ASCII character as ``\uXXXX``.
+
+    Args:
+        match: Match holding exactly one non-ASCII character.
+
+    Returns:
+        The ``\uXXXX`` escape sequence, or a UTF-16 surrogate pair for
+        characters beyond the BMP.
+    """
+    code = ord(match.group())
+    if code <= 0xFFFF:
+        return f"\\u{code:04x}"
+    # Astral plane: emit a UTF-16 surrogate pair like stdlib json does.
+    code -= 0x10000
+    return f"\\u{0xD800 + (code >> 10):04x}\\u{0xDC00 + (code & 0x3FF):04x}"
+
+
+def _escape_non_ascii(text: str) -> str:
+    r"""Escape every non-ASCII character in a JSON document as ``\uXXXX``.
+
+    All structural characters of a JSON document are ASCII, so any non-ASCII
+    code point necessarily sits inside a string literal. Escaping them
+    individually therefore yields an equivalent, ASCII-only document.
+
+    Only the matched characters are substituted, so contiguous ASCII runs are
+    copied as-is instead of being buffered one object per character.
+
+    Args:
+        text: A valid JSON document.
+
+    Returns:
+        The same document with non-ASCII characters replaced by ``\uXXXX``
+        escape sequences, matching the stdlib json encoder.
+    """
+    return _NON_ASCII_PATTERN.sub(_escape_match, text)
 
 
 class OrjsonProvider:
@@ -155,6 +198,9 @@ class OrjsonProvider:
             - separators -> stdlib fallback (orjson doesn't support)
             - indent=4 or other -> ujson/rapidjson/stdlib fallback
             - indent=2 or None -> native orjson (maximum performance)
+            - ensure_ascii=True with non-ASCII output -> orjson's output is
+              escaped in place (orjson has no ensure_ascii option and always
+              emits raw UTF-8)
         """
         # Case 1: separators requested -> must use stdlib
         if separators is not None:
@@ -187,9 +233,22 @@ class OrjsonProvider:
         # orjson always returns bytes, decode to str
         try:
             result = orjson.dumps(obj, option=option)
-            return result.decode("utf-8")
         except (TypeError, ValueError) as e:
             raise JSONEncodeError(f"Object not JSON serializable: {e}") from e
+
+        text = result.decode("utf-8")
+
+        # orjson has no `ensure_ascii` option and always emits raw UTF-8. Escape
+        # the serialized output instead of re-encoding ``obj`` through another
+        # backend: that preserves orjson's formatting as well as its wider type
+        # support (dataclasses, datetime, non-finite floats), which a fallback
+        # provider would either reject or serialize with different semantics.
+        # Pure-ASCII output needs no escaping, so the fast path is untouched.
+        if ensure_ascii and not text.isascii():
+            logger.debug("orjson: escaping non-ASCII output for ensure_ascii=True")
+            return _escape_non_ascii(text)
+
+        return text
 
     def loads(self, s: str | bytes) -> Any:
         """Deserialize JSON string using orjson.

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,5 +1,7 @@
 """Tests for JSON provider implementations."""
 
+from datetime import datetime
+
 import pytest
 
 from audible.json_provider import (
@@ -313,6 +315,112 @@ class TestOrjsonProvider:
         serialized = provider.dumps(original, indent=4)
         deserialized = provider.loads(serialized)
         assert deserialized == original
+
+    def test_dumps_ensure_ascii_true_ascii_fast_path(self) -> None:
+        """ASCII-only output stays on the native orjson path (no fallback)."""
+        try:
+            provider = OrjsonProvider()
+        except ImportError:
+            pytest.skip("orjson not installed")
+
+        result = provider.dumps({"key": "value"}, ensure_ascii=True)
+        assert result == '{"key":"value"}'
+
+    def test_dumps_ensure_ascii_true_non_ascii(self) -> None:
+        """ensure_ascii=True escapes non-ASCII via the fallback provider."""
+        try:
+            provider = OrjsonProvider()
+        except ImportError:
+            pytest.skip("orjson not installed")
+
+        result = provider.dumps({"key": "über"}, ensure_ascii=True)
+        # Escaped to \uXXXX; lower() tolerates rapidjson's uppercase hex.
+        assert "\\u00fc" in result.lower()
+        assert "ü" not in result
+
+    def test_dumps_ensure_ascii_false_non_ascii(self) -> None:
+        """ensure_ascii=False keeps orjson's raw UTF-8 output."""
+        try:
+            provider = OrjsonProvider()
+        except ImportError:
+            pytest.skip("orjson not installed")
+
+        result = provider.dumps({"key": "über"}, ensure_ascii=False)
+        assert "über" in result
+
+    def test_dumps_indent_2_ensure_ascii_true_non_ascii(self) -> None:
+        """indent=2 with non-ASCII stays indented and gets escaped."""
+        try:
+            provider = OrjsonProvider()
+        except ImportError:
+            pytest.skip("orjson not installed")
+
+        result = provider.dumps({"key": "über"}, indent=2, ensure_ascii=True)
+        assert '  "key"' in result
+        assert "\\u00fc" in result.lower()
+        assert "ü" not in result
+
+    def test_dumps_ensure_ascii_true_keeps_compact_separators(self) -> None:
+        """Escaping happens in place, so orjson's compact separators survive."""
+        try:
+            provider = OrjsonProvider()
+        except ImportError:
+            pytest.skip("orjson not installed")
+
+        result = provider.dumps({"key": "über"}, ensure_ascii=True)
+        assert result == '{"key":"\\u00fcber"}'
+
+    def test_dumps_ensure_ascii_true_astral_surrogate_pair(self) -> None:
+        """Characters beyond the BMP are escaped as UTF-16 surrogate pairs."""
+        try:
+            provider = OrjsonProvider()
+        except ImportError:
+            pytest.skip("orjson not installed")
+
+        result = provider.dumps({"key": "😀"}, ensure_ascii=True)
+        assert result == '{"key":"\\ud83d\\ude00"}'
+        assert provider.loads(result) == {"key": "😀"}
+
+    def test_dumps_ensure_ascii_true_keeps_orjson_only_types(self) -> None:
+        """orjson-native types still serialize alongside non-ASCII text."""
+        try:
+            provider = OrjsonProvider()
+        except ImportError:
+            pytest.skip("orjson not installed")
+
+        # stdlib/ujson cannot encode datetime; escaping in place must not
+        # re-encode the object through a less capable backend.
+        result = provider.dumps(
+            {"when": datetime(2026, 7, 21, 8, 30), "label": "über"},
+            ensure_ascii=True,
+        )
+        assert "2026-07-21T08:30:00" in result
+        assert "\\u00fc" in result
+        assert "ü" not in result
+
+    def test_dumps_ensure_ascii_true_keeps_non_finite_float_semantics(self) -> None:
+        """Non-finite floats keep orjson's null semantics, not stdlib's NaN."""
+        try:
+            provider = OrjsonProvider()
+        except ImportError:
+            pytest.skip("orjson not installed")
+
+        result = provider.dumps(
+            {"value": float("nan"), "label": "über"}, ensure_ascii=True
+        )
+        assert '"value":null' in result
+        assert "NaN" not in result
+        assert "\\u00fc" in result
+
+    def test_roundtrip_non_ascii(self) -> None:
+        """Non-ASCII data round-trips through dumps/loads."""
+        try:
+            provider = OrjsonProvider()
+        except ImportError:
+            pytest.skip("orjson not installed")
+
+        original = {"key": "über", "number": 1}
+        assert provider.loads(provider.dumps(original)) == original
 
 
 class TestRegistry:


### PR DESCRIPTION
## Problem

`OrjsonProvider` accepted `ensure_ascii` but silently ignored it on its native path (`indent=None` or `indent=2`). orjson has no such option and always emits raw UTF-8, so `dumps({"x": "ü"}, ensure_ascii=True)` returned the umlaut verbatim while ujson, rapidjson and stdlib all escaped it to its ASCII form.

The serialized bytes therefore depended on which JSON library happened to be installed, breaking the contract declared in the `JSONProvider` protocol (`protocols.py`).

## Fix

Escape orjson's serialized output **in place** rather than re-encoding the object through a fallback provider.

Re-encoding was the obvious approach but regresses inputs orjson supports natively while the fallbacks do not:

- a `datetime` combined with non-ASCII text would raise `JSONEncodeError`
- non-finite floats would silently change semantics — orjson emits `null`, stdlib emits `NaN`, which isn't even valid JSON

Escaping the finished document avoids both and preserves orjson's exact formatting.

Substitution uses a compiled regex, so contiguous ASCII runs are copied as-is instead of being buffered one object per character. Characters beyond the BMP become UTF-16 surrogate pairs, matching the stdlib encoder. Pure-ASCII output short-circuits via `str.isascii()`, so the fast path is untouched.

## Impact

No caller in this library is affected today — the only compact call site (`login.py`) passes ASCII-only data, and the `auth.py` / `aescipher.py` call sites use `indent=4`, which already routed to a fallback that honors `ensure_ascii`. `OrjsonProvider` is public API though, so the contract matters for downstream users.

## Tests

9 new cases in `TestOrjsonProvider`: ASCII fast path, non-ASCII escaping, `ensure_ascii=False`, `indent=2`, compact separators, astral surrogate pairs, `datetime` preservation, non-finite float semantics, and a round-trip.

## Verification

- `uv run nox` — all 16 sessions green across Python 3.11–3.14
- 84 JSON tests pass with orjson + ujson + rapidjson installed; 19 pass with orjson only
- Memory profile is linear: 5M characters escape at a 10 MB peak
