### PR TITLE
chore(nox): default UV_VENV_CLEAR so repeated local runs work

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -24,6 +24,13 @@ nox.options.sessions = (
     "docs-build",
 )
 
+# uv refuses to create a virtualenv where one already exists, so a plain
+# `nox` run fails for every session once `.nox/` has been populated by an
+# earlier run. Clearing on create keeps repeated local runs working, while
+# `nox -R` still reuses the existing environments. CI starts from an empty
+# `.nox/`, where this is a no-op.
+os.environ.setdefault("UV_VENV_CLEAR", "1")
+
 PACKAGE = "audible"
 PROJECT = nox.project.load_toml("pyproject.toml")
 PYTHON_VERSIONS = nox.project.python_versions(PROJECT)


### PR DESCRIPTION
## Problem

`uv` refuses to create a virtualenv where one already exists. Once `.nox/` has been populated by an earlier run, a plain `uv run nox` fails for **every** session:

```
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at: .nox/tests-3-14
hint: Use the `--clear` flag or set UV_VENV_CLEAR=1
```

The run still exits 0 while not executing a single test, so it looks like a pass at a glance. That is a nasty trap given the project requires a full `uv run nox` before every push.

## Fix

Set `UV_VENV_CLEAR=1` at module level in `noxfile.py` so nox recreates the environments instead of erroring out.

`os.environ.setdefault()` is used deliberately: an explicit value from the shell stays authoritative, so the noxfile provides a default rather than forcing behavior.

## Scope

Sessions invoked with `--reuse-existing-virtualenvs` (`-r`) are unaffected — nox then skips venv creation entirely, so the variable never applies. Verified with a marker file that survives both runs of the CI coverage job, which calls the `coverage` session twice on the same runner:

```
nox > Reusing existing virtual environment at .nox/coverage.
  -> marker survived: clear did NOT run
```

In CI this is a no-op anyway, since runners start with an empty `.nox/`. No workflow changes are needed.

## Verification

- `uv run nox` with a pre-populated `.nox/` — all 16 sessions green (previously all 16 failed)
- `uv run nox -s tests-3.14 -R` — still reports `Reusing existing virtual environment`
- `mypy` covers `noxfile.py` itself and reports no issues
