### PR TITLE
ci(release): restrict GITHUB_TOKEN permissions on the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      # Push the version tag and publish the drafted release.
+      contents: write
+      # Release Drafter reads merged pull requests and their labels to
+      # categorize the release notes.
+      pull-requests: read
     outputs:
       tag: ${{ steps.check-version.outputs.tag }}
     steps:


### PR DESCRIPTION
Resolves the open CodeQL alert `actions/missing-workflow-permissions` (medium) on `.github/workflows/release.yml:14`.

## Problem

The `release` job carried no `permissions` block, so it ran with the default `GITHUB_TOKEN` scope instead of an explicit, minimal one. The `pypi-publish` job in the same file already declared its own scope (`id-token: write`), so only the first job was affected.

## Change

Grant the `release` job exactly what it uses:

| Permission | Needed by |
| --- | --- |
| `contents: write` | `salsify/action-detect-and-tag-new-version` pushes the version tag; `release-drafter` publishes the release |
| `pull-requests: read` | `release-drafter` reads merged PRs and their labels to categorize the release notes |

`pull-requests: read` is deliberately included: without it Release Drafter cannot read PR labels, and the notes would lose their category grouping (`:package: Dependencies`, `:beetle: Fixes`, …) configured in `.github/release-drafter.yml`.

The `pypi-publish` job is left untouched.

## Verification

YAML parses and both jobs now declare explicit scopes:

```
release.permissions:      {'contents': 'write', 'pull-requests': 'read'}
pypi-publish.permissions: {'id-token': 'write'}
```

`pre-commit` (including the YAML and prettier hooks) passes.

Note that the release workflow only runs on push to `master`, so this cannot be exercised end-to-end from a pull request — the permissions above were derived from what each action documents as its minimum.
