### PR TITLE
ci(docs): install Read the Docs dependencies with uv

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,5 +9,12 @@ formats:
   - pdf
 python:
   install:
-    - requirements: docs/requirements.txt
-    - path: .
+    # Runs `uv sync --group docs`, which installs the docs dependency group from
+    # pyproject.toml together with the project itself, replacing the previous pair
+    # of entries (docs/requirements.txt + path: .). Doc dependency versions are
+    # therefore maintained in pyproject.toml only. Note that `method: uv` allows
+    # exactly one entry here.
+    - method: uv
+      command: sync
+      groups:
+        - docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,0 @@
-sphinx==9.1.0
-sphinx-autobuild==2025.8.25
-sphinx-autodoc-typehints==3.12.1
-sphinx-rtd-theme==3.1.0
-sphinxcontrib-httpdomain==2.0.0
-myst_parser==5.1.0


### PR DESCRIPTION
Phase 1 of the workflow modernization: make `pyproject.toml` the single source of truth for documentation dependencies.

## Problem

Doc dependencies were declared twice:

- `[dependency-groups] docs` in `pyproject.toml` — used by the nox `docs-build` session
- `docs/requirements.txt` — used by Read the Docs via `.readthedocs.yml`

They drift, and the drift is invisible: **no CI job reads `docs/requirements.txt`**. Two recent Renovate PRs (#837, #853) reported 37/37 green checks while changing a file that CI never touches. A broken pin there would only have surfaced on the published documentation.

## Change

Read the Docs now installs via uv, which is natively supported:

```yaml
python:
  install:
    - method: uv
      command: sync
      groups:
        - docs
```

This runs `uv sync --group docs`, which installs the docs group **and the project itself** — so it replaces both previous entries (`requirements: docs/requirements.txt` and `path: .`). Note that `method: uv` allows exactly one entry under `python.install`.

`docs/requirements.txt` is deleted. Doc dependency versions live in `pyproject.toml` only, and Renovate has a single place to update.

The file is also renamed `.readthedocs.yml` → `.readthedocs.yaml`, which is the canonical name in the RTD v2 schema.

## Verification

Built in an isolated environment created exactly the way RTD will create it (`uv sync --group docs`, Python 3.14):

- `audible 0.11.0` importable, so autodoc resolves — this confirms the dropped `path: .` entry is covered
- sphinx 9.1.0, myst-parser 5.1.0, sphinx-rtd-theme 3.1.0, sphinx-autodoc-typehints 3.12.1, sphinxcontrib-httpdomain 2.0.0
- HTML build succeeds with 16 warnings — unchanged from the current setup
- LaTeX build succeeds and produces `audible.tex`, so the `formats: [pdf]` path still works

`uv run nox` passes all 16 sessions.

## Before merging

Two things need checking on the Read the Docs side, which cannot be verified from the repository:

1. Whether the RTD project has an **explicit config file path** configured pointing at `.readthedocs.yml`. If so it must be updated to `.readthedocs.yaml`, otherwise RTD will not find the renamed file.
2. The **RTD pull request preview build** for this PR. CI cannot exercise this path at all, so the preview is the only real proof before merging.
