### PR TITLE
docs: build without warnings and keep it that way

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,10 @@ build:
     python: "3.14"
 sphinx:
   configuration: docs/source/conf.py
+  # The build is warning-free; keep it that way. A new warning is almost always a
+  # real regression (a broken cross-reference, a dead include, an ambiguous
+  # target) and is easy to miss in a wall of accepted noise.
+  fail_on_warning: true
 formats:
   - pdf
 python:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,7 +83,5 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 #
 html_theme = "sphinx_rtd_theme"
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# No custom static files are used, so html_static_path is left unset. Setting it
+# to a directory that does not exist makes Sphinx emit a warning on every build.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,29 +2,32 @@
 Audible |version| documentation!
 ================================
 
-.. image:: https://img.shields.io/pypi/v/audible.svg
-   :target: https://pypi.org/project/audible/
+.. Badges are SVG and cannot be embedded by the latex builder, which makes the
+   pdf build warn about each one. They carry no meaning in a pdf anyway, so they
+   are restricted to the html output.
 
-.. image:: https://img.shields.io/pypi/l/audible.svg
-   :target: https://pypi.org/project/audible
+.. only:: html
 
-.. image:: https://img.shields.io/pypi/pyversions/audible.svg
-   :target: https://pypi.org/project/audible
+   .. image:: https://img.shields.io/pypi/v/audible.svg
+      :target: https://pypi.org/project/audible/
 
-.. image:: https://img.shields.io/pypi/status/audible.svg
-   :target: https://pypi.org/project/audible
+   .. image:: https://img.shields.io/pypi/l/audible.svg
+      :target: https://pypi.org/project/audible
 
-.. image:: https://img.shields.io/pypi/wheel/audible.svg
-   :target: https://pypi.org/project/audible
+   .. image:: https://img.shields.io/pypi/pyversions/audible.svg
+      :target: https://pypi.org/project/audible
 
-.. image:: https://img.shields.io/travis/mkb79/audible/master.svg?logo=travis
-   :target: https://travis-ci.org/mkb79/audible
+   .. image:: https://img.shields.io/pypi/status/audible.svg
+      :target: https://pypi.org/project/audible
 
-.. image:: https://www.codefactor.io/repository/github/mkb79/audible/badge
-   :target: https://www.codefactor.io/repository/github/mkb79/audible
+   .. image:: https://img.shields.io/pypi/wheel/audible.svg
+      :target: https://pypi.org/project/audible
 
-.. image:: https://img.shields.io/pypi/dm/audible.svg
-   :target: https://pypi.org/project/audible
+   .. image:: https://www.codefactor.io/repository/github/mkb79/audible/badge
+      :target: https://www.codefactor.io/repository/github/mkb79/audible
+
+   .. image:: https://img.shields.io/pypi/dm/audible.svg
+      :target: https://pypi.org/project/audible
 
 -------------------
 

--- a/docs/source/modules/audible.rst
+++ b/docs/source/modules/audible.rst
@@ -117,10 +117,16 @@ audible.json\_provider.protocols module
 audible.json\_provider.exceptions module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. JSONDecodeError and JSONEncodeError are re-exported from the package and are
+   documented there, which is also how users import them. ``:no-index:`` keeps
+   this section readable while leaving ``audible.json_provider`` as the single
+   cross-reference target.
+
 .. automodule:: audible.json_provider.exceptions
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 audible.json\_provider.registry module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -173,10 +179,15 @@ audible.localization module
 audible.login module
 --------------------
 
+.. ``:undoc-members:`` pulls in the bs4 classes imported by this module and then
+   documents them as ``audible.login.*``. Excluding them keeps third-party types
+   out of our API reference and avoids resolving bs4's own forward references.
+
 .. automodule:: audible.login
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: BeautifulSoup, NavigableString, Tag
 
 audible.metadata module
 -----------------------

--- a/noxfile.py
+++ b/noxfile.py
@@ -235,7 +235,10 @@ def xdoctest(s: nox.Session) -> None:
 @session(name="docs-build", python=DEFAULT_PYTHON_VERSION, uv_groups=[DOCS_GROUP])
 def docs_build(s: nox.Session) -> None:
     """Build the documentation."""
-    default_args = ["docs/source", "docs/_build"]
+    # -W turns warnings into errors, matching `fail_on_warning` in
+    # .readthedocs.yaml. Catching them here gives feedback on the pull request
+    # instead of only when Read the Docs builds.
+    default_args = ["-W", "docs/source", "docs/_build"]
     args = s.posargs or default_args
 
     if not s.posargs and "FORCE_COLOR" in os.environ:

--- a/src/audible/client.py
+++ b/src/audible/client.py
@@ -13,7 +13,12 @@ from typing import (
 )
 
 import httpx
-from httpx import URL
+
+# `Headers` must stay importable under this name: httpx defines `HeaderTypes` as
+# `ForwardRef("Headers") | ...`, and that forward reference is resolved in the
+# namespace of the module using the annotation. Without the binding, tools that
+# evaluate annotations (sphinx-autodoc-typehints among them) cannot resolve it.
+from httpx import URL, Headers
 from httpx._models import HeaderTypes  # type: ignore[attr-defined]
 
 from ._types import TrueFalseT
@@ -96,7 +101,7 @@ class BaseClient(Generic[ClientT], metaclass=ABCMeta):
             raise Exception("Authenticator has no `Locale` class set.")
         self._api_url = httpx.URL(self._API_URL_TEMP + locale.domain)
 
-        default_headers = httpx.Headers(
+        default_headers = Headers(
             {
                 "Accept": "application/json",
                 "Accept-Charset": "utf-8",

--- a/src/audible/crypto_provider/protocols.py
+++ b/src/audible/crypto_provider/protocols.py
@@ -15,12 +15,10 @@ class HashAlgorithm(Protocol):
 
     This protocol defines the interface that hash objects must provide.
     Compatible with hashlib hash objects (e.g., hashlib.sha256()).
-
-    Attributes:
-        name: The name of the hash algorithm (e.g., 'sha256', 'sha1').
     """
 
     name: str
+    """The name of the hash algorithm (e.g., 'sha256', 'sha1')."""
 
 
 @runtime_checkable


### PR DESCRIPTION
Part of #864 (phase 1b).

The docs built with **16 warnings for html and 24 for latex**. In that much accepted noise a real regression is invisible — the html count quietly went from 15 to 16 during the recent sphinx upgrade in #860, and only surfaced because the two builds were compared deliberately.

Every cause is fixed rather than suppressed. **Both builders are now warning-free.**

## Causes and fixes

| Warnings | Cause | Fix |
| ---: | --- | --- |
| 1 | `html_static_path` pointed at `docs/source/_static`, which does not exist | Dropped — no custom static files are used |
| 5 | httpx defines `HeaderTypes` as `ForwardRef("Headers") \| ...`; that forward reference resolves in the namespace of the module carrying the annotation, and `audible.client` only bound `httpx`, never `Headers` | Import `Headers` directly and use it where `httpx.Headers` was used, so the name is genuinely needed rather than an unused import |
| 1 | `HashAlgorithm.name` documented twice — once via the `Attributes:` docstring section, once via the annotated class variable picked up by `:undoc-members:` | Document it at the declaration instead |
| 8 | `JSONDecodeError`/`JSONEncodeError` are re-exported from the package **and** documented in the exceptions submodule, so every reference has two equal targets | `:no-index:` on the submodule; the package stays the single target, matching how users import them |
| 1 | `:undoc-members:` pulled bs4 classes imported by `audible.login` into our API reference, which then tried to resolve bs4's own forward references | `:exclude-members:` for those classes |
| 8 (latex) | SVG badges cannot be embedded by the latex builder | Restricted to html via `.. only:: html` |

## Keeping it that way

With both builders clean, the gate is now enforced in **two** places:

- `fail_on_warning: true` in `.readthedocs.yaml`
- `-W` in the nox `docs-build` session

The second matters: it turns a docs regression into a **failing pull request** instead of something noticed only after the published documentation degrades. Verified by deliberately introducing a broken `include`, which made the session exit non-zero as intended.

## Also

The **Travis CI badge is removed**. `travis-ci.org` has been shut down for years and this project builds on GitHub Actions, so it rendered as a broken image for every visitor.

## Verification

- html: 16 → **0** warnings, clean rebuild (`-E`)
- latex: 24 → **0** warnings, `audible.tex` still produced for the `formats: [pdf]` path
- badges still render in the html output; only the dead Travis one is gone
- `uv run nox` — all 16 sessions green

## Noted, not changed

`src/audible/client.py` imports `HeaderTypes` from the **private** module `httpx._models`, with a `# type: ignore[attr-defined]` because it is not public API. That is the underlying reason the forward reference exists at all, and httpx can move or rename it in any release without it counting as a breaking change. Out of scope for a docs fix, but worth a separate look.
