### PR TITLE
ci(security): run Scorecard on master pushes too

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -71,8 +71,17 @@ jobs:
   scorecard:
     # Informational only, and deliberately not part of the gate: the score
     # reacts to repository settings rather than to the change under review.
+    #
+    # Runs on master pushes as well as on the schedule. Scorecard grades the
+    # repository's configuration -- workflow permissions, pinned actions,
+    # branch protection -- and merging changes that configuration, so a weekly
+    # measurement would lag behind reality. Not on pull requests: the settings
+    # it grades cannot be changed by a pull request, and a score that moves for
+    # unrelated reasons must never block one.
     name: scorecard
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Follow-up to #869.

Scorecard grades the **repository's configuration** — workflow permissions, pinned actions, branch protection — not the code. Merging changes that configuration, so a weekly measurement lags behind reality in between.

#869 is the concrete case: adding `security.yml` and removing `safety` moved both the `TokenPermissions` and `PinnedDependencies` findings immediately, but the recorded score only caught up when the workflow was dispatched by hand.

Phases 4 to 8 in #864 will pin every action to a commit SHA, add a tag ruleset and CODEOWNERS, rewrite `release.yml` and delete three workflows. Each of those changes should be measurable against the merge that caused it, not whenever the next Monday comes around.

## What stays unchanged

**Not on pull requests.** A pull request cannot change the settings Scorecard grades, so the result would be identical for every PR — and a score that moves for unrelated reasons (a settings change, an OpenSSF heuristic update) must never block someone else's work.

**Still outside the gate**, for the same reason. `security` continues to depend only on `audit` and `dependency-review`.

The weekly schedule and `workflow_dispatch` both remain, so a deliberate before/after measurement is still possible when changing a setting by hand.

## Cost

One extra run per merge to master, roughly two minutes, unable to block anything. This matches the official OpenSSF workflow, which also runs on pushes to the default branch.
