### PR TITLE
ci: pin actions to commit SHAs and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# Code owners for this repository.
+#
+# "Require review from Code Owners" is deliberately disabled in the branch
+# protection rules: this is a solo-maintainer project, and a review requirement
+# the maintainer cannot satisfy would block every pull request. This file
+# therefore documents ownership and drives review requests, rather than gating
+# merges.
+#
+# The paths listed here are the ones where a mistake is expensive or hard to
+# notice: they decide what gets published, under which version, and with which
+# credentials.
+
+# Everything, unless a more specific rule below matches.
+*                               @mkb79
+
+# Release and CI machinery. A change here can publish, tag, or hand out
+# credentials.
+/.github/workflows/             @mkb79
+/.github/CODEOWNERS             @mkb79
+
+# Build metadata and the lock file. The version, the published dependency
+# constraints, and the resolved set all live here.
+/pyproject.toml                 @mkb79
+/uv.lock                        @mkb79
+
+# Changelog. Entries for published releases must never change wording.
+/CHANGELOG.md                   @mkb79
+
+# Security policy and dependency automation.
+/SECURITY.md                    @mkb79
+/renovate.json5                 @mkb79

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: ${{ env.UV_VERSION }}
           python-version: "3.14"
@@ -74,10 +74,10 @@ jobs:
           - { python: "3.14", os: macos-latest }
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ matrix.python }}
@@ -93,7 +93,7 @@ jobs:
         if: >-
           always() && matrix.os == 'ubuntu-latest' &&
           (matrix.python == '3.11' || matrix.python == '3.14')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-data-${{ matrix.python }}
           include-hidden-files: true
@@ -105,10 +105,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: ${{ env.UV_VERSION }}
           python-version: "3.14"
@@ -130,16 +130,16 @@ jobs:
     needs: tests
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: ${{ env.UV_VERSION }}
           python-version: "3.14"
 
       - name: Download coverage data
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -151,7 +151,7 @@ jobs:
         run: uv run nox --reuse-existing-virtualenvs --session=coverage -- xml
 
       - name: Upload the coverage report
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Review dependency changes
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: moderate
           # No license policy is defined for this project, so do not invent one
@@ -57,10 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: ${{ env.UV_VERSION }}
           python-version: "3.14"
@@ -91,18 +91,18 @@ jobs:
       security-events: write
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
 
       - name: Upload the results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: results.sarif
 


### PR DESCRIPTION
Part of #864 (phase 4) — my half of it. The GitHub App, tag ruleset, environments and trusted publishers are configured separately by the maintainer.

## Pinned actions

A version tag is **mutable**. Whoever controls an action's repository can move `v7` to different code, and the next run picks it up with no change on our side. All 20 action references in the three workflows that survive are pinned to the commit they currently resolve to:

```yaml
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
```

The trailing comment is not decoration — Renovate reads it, keeps the pin updated and rewrites both parts together, so the diff stays readable. With the rule from #868 these updates land as `ci(deps)`.

Two tags did not resolve straightforwardly:

- **`dependency-review-action` has no floating `v5` tag at all.** `@v5` resolves through a *branch* of that name. Pinned to the commit it points at, which is the same one `v5.0.0` tags.
- **`codeql-action`'s `v4` is an annotated tag**, so the ref points at a tag object rather than a commit. Dereferenced to the underlying commit.

Both would have been easy to get wrong by taking the first SHA the API returns.

### What is deliberately not pinned

`release.yml` is rewritten in phase 6; `labeler.yml`, `stale.yml` and `uv-lock-maintenance.yml` are deleted in phase 8. Pinning them now would be thrown away, and their Scorecard findings disappear with the files.

That means the `PinnedDependencies` count drops but does not reach zero yet — 20 of the 35 findings are addressed here, the rest resolve as those files go away.

## CODEOWNERS

Documents ownership of the paths where a mistake is expensive or hard to notice: workflows, `pyproject.toml`, `uv.lock`, `CHANGELOG.md`, `SECURITY.md` and `renovate.json5` — the files that decide what gets published, under which version, and with which credentials.

It **does not gate merges**. "Require review from Code Owners" stays disabled, since a solo maintainer cannot approve their own pull requests. The file drives review requests and records intent; the actual guarantees in phase 6 come from the tag ruleset and the verification job, which work regardless of who is reviewing.

## Verification

- Every SHA resolved through the API against the tag or branch the workflow currently uses
- No unpinned action reference remains in the three files
- All three workflows still parse; `pre-commit` passes
