### PR TITLE
ci(release): add the changelog surgery a release performs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -197,7 +197,7 @@ def audit(s: nox.Session) -> None:
 )
 def mypy(s: nox.Session) -> None:
     """Type-check using mypy."""
-    default_args = ["src/audible", "tests", "docs/source/conf.py"]
+    default_args = ["src/audible", "tests", "tools", "docs/source/conf.py"]
     args = s.posargs or default_args
 
     s.run("mypy", *args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,9 @@ exclude_lines = [
 
 [tool.mypy]
 python_version = "3.11"
+# tools/ is repository tooling rather than part of the package, but the tests
+# import from it, so it has to be resolvable.
+mypy_path = "tools"
 pretty = true
 show_column_numbers = true
 show_error_codes = true
@@ -234,7 +237,9 @@ convention = "google"
 
 [tool.ruff.lint.isort]
 force-single-line = false
-known-first-party = ["audible"]
+# changelog and the release helpers live in tools/ and are imported by the
+# tests, so they sort with the project rather than with third-party packages.
+known-first-party = ["audible", "changelog", "prepare_release"]
 lines-after-imports = 2
 
 [tool.ruff.lint.per-file-ignores]
@@ -246,6 +251,9 @@ lines-after-imports = 2
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "src/audible"]
+# tools/ holds the changelog and release helpers. They are repository tooling
+# rather than part of the package, but they are tested like anything else.
+pythonpath = ["tools"]
 
 [tool.pydoclint]
 style = "google"

--- a/tests/test_changelog_integrity.py
+++ b/tests/test_changelog_integrity.py
@@ -6,88 +6,25 @@ history that users have already read.
 
 `.changelog-manifest.json` records a hash per published section. This test
 recomputes them, so any edit to a released section fails the pull request
-instead of being noticed later, or not at all. The release tooling appends a
-new entry when it publishes; nothing removes or rewrites existing ones.
+instead of being noticed later, or not at all.
+
+This only compares the two files against each other. Rewriting a section *and*
+its hash in the same change is self-consistent and passes here; that case is
+caught by tools/check_manifest_append_only.py, which compares against the base
+branch.
 """
 
-import hashlib
-import json
-import re
 from collections import Counter
 from pathlib import Path
 
 import pytest
 
+from changelog import UNRELEASED, digest, load_manifest, split_sections
+
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CHANGELOG = REPO_ROOT / "CHANGELOG.md"
 MANIFEST = REPO_ROOT / ".changelog-manifest.json"
-
-# Two heading styles have to be recognised. Sections written before releases
-# were generated look like "## [0.11.0] - 2026-07-20", and "## [Unreleased]"
-# uses the same bracketed form. Generated sections look like
-# "## v0.12.0 (2026-07-22)".
-#
-# Matching only the bracketed form would make every future section invisible to
-# this test: it would not appear as published, so nothing would report it as
-# unprotected either. The gap would be silent.
-#
-# Neither alternative matches "## Bugfix", which older sections contain as a
-# subheading at the same level and which is content, not a boundary.
-SECTION_HEADING = re.compile(
-    r"^## (?:\[(?P<bracketed>[^\]]+)\]|v(?P<generated>\d+\.\d+\.\d+))",
-    re.MULTILINE,
-)
-
-
-def _version_of(match: re.Match[str]) -> str:
-    """Return the version a section heading refers to.
-
-    Args:
-        match: A match of :data:`SECTION_HEADING`.
-
-    Returns:
-        The version string, without the leading ``v`` of generated headings.
-    """
-    return match.group("bracketed") or match.group("generated")
-
-
-UNRELEASED = "Unreleased"
-
-
-def split_sections(text: str) -> list[tuple[str, str]]:
-    """Split a changelog into its sections.
-
-    Returns a list rather than a mapping on purpose. A mapping would silently
-    collapse two sections carrying the same version, which is exactly the state
-    a botched release would leave behind, and it would hide it from every check
-    built on top.
-
-    Args:
-        text: Full contents of the changelog.
-
-    Returns:
-        Pairs of version and the exact text of its section, heading included,
-        in the order they appear.
-    """
-    marks = [(m.start(), _version_of(m)) for m in SECTION_HEADING.finditer(text)]
-    sections = []
-    for index, (start, version) in enumerate(marks):
-        end = marks[index + 1][0] if index + 1 < len(marks) else len(text)
-        sections.append((version, text[start:end]))
-    return sections
-
-
-def digest(section: str) -> str:
-    """Return the hash recorded for a section.
-
-    Args:
-        section: Exact text of one changelog section.
-
-    Returns:
-        Hex-encoded SHA-256 of the section's UTF-8 bytes.
-    """
-    return hashlib.sha256(section.encode("utf-8")).hexdigest()
 
 
 @pytest.fixture(scope="module")
@@ -107,10 +44,7 @@ def manifest_entries() -> list[dict[str, str]]:
     Returns:
         The raw entries, so duplicates stay visible.
     """
-    data: dict[str, list[dict[str, str]]] = json.loads(
-        MANIFEST.read_text(encoding="utf-8")
-    )
-    return data["sections"]
+    return load_manifest(MANIFEST)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -1,0 +1,188 @@
+"""Tests for the changelog surgery performed during a release.
+
+This edits a file whose older content must not change, so the failure modes are
+exercised here rather than discovered while a release is half-finished. The
+tests drive :func:`prepare` against temporary files, not only the splice helper,
+because the ordering of validation and writing is itself part of the guarantee.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from changelog import digest, prepend_section, split_sections
+from prepare_release import prepare
+
+
+EXISTING = """# Changelog
+
+Some introduction that belongs to no section.
+
+## v0.11.0 (2026-07-20)
+
+### Feat
+
+- an entry whose wording must survive
+
+## Bugfix
+
+- a subheading that is content, not a boundary
+
+## [0.10.0] - 2024-09-26
+
+### Added
+
+- an older entry
+"""
+
+FRAGMENT = """## v0.12.0 (2026-07-22)
+
+### Feat
+
+- something new
+"""
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> tuple[Path, Path]:
+    """A changelog and manifest to operate on.
+
+    Args:
+        tmp_path: Temporary directory supplied by pytest.
+
+    Returns:
+        Paths to the changelog and the manifest.
+    """
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(EXISTING, encoding="utf-8")
+    manifest = tmp_path / ".changelog-manifest.json"
+    entries = [
+        {"version": version, "sha256": digest(section)}
+        for version, section in split_sections(EXISTING)
+    ]
+    manifest.write_text(json.dumps({"sections": entries}, indent=2) + "\n")
+    return changelog, manifest
+
+
+def test_the_release_lands_above_the_previous_one(repo: tuple[Path, Path]) -> None:
+    """The prepared release becomes the newest section."""
+    changelog, manifest = repo
+    prepare("0.12.0", FRAGMENT, changelog, manifest)
+    versions = [v for v, _ in split_sections(changelog.read_text(encoding="utf-8"))]
+    assert versions == ["0.12.0", "0.11.0", "0.10.0"]
+
+
+def test_existing_sections_are_byte_identical_afterwards(
+    repo: tuple[Path, Path],
+) -> None:
+    """Inserting must not disturb a single character of released text."""
+    changelog, manifest = repo
+    before = dict(split_sections(EXISTING))
+    prepare("0.12.0", FRAGMENT, changelog, manifest)
+    after = dict(split_sections(changelog.read_text(encoding="utf-8")))
+    for version, section in before.items():
+        assert after[version] == section, f"the section for {version} changed"
+
+
+def test_the_recorded_hash_describes_the_file(repo: tuple[Path, Path]) -> None:
+    """The manifest must match what actually landed, not the input text.
+
+    Freezing the fragment instead would record something differing from the file
+    by whitespace, and the mismatch would only appear on the next pull request.
+    """
+    changelog, manifest = repo
+    prepare("0.12.0", FRAGMENT, changelog, manifest)
+
+    written = dict(split_sections(changelog.read_text(encoding="utf-8")))["0.12.0"]
+    recorded = {
+        entry["version"]: entry["sha256"]
+        for entry in json.loads(manifest.read_text())["sections"]
+    }
+    assert recorded["0.12.0"] == digest(written)
+    assert digest(written) != digest(FRAGMENT), (
+        "the test would not distinguish the two if they happened to be equal"
+    )
+
+
+def test_the_manifest_only_grows(repo: tuple[Path, Path]) -> None:
+    """Existing entries keep their value and their position."""
+    changelog, manifest = repo
+    before = json.loads(manifest.read_text())["sections"]
+    prepare("0.12.0", FRAGMENT, changelog, manifest)
+    after = json.loads(manifest.read_text())["sections"]
+    assert after[: len(before)] == before
+    assert after[-1]["version"] == "0.12.0"
+
+
+@pytest.mark.parametrize(
+    ("version", "fragment", "expected"),
+    [
+        ("0.12.0", FRAGMENT.replace("v0.12.0", "v0.13.0"), "the fragment is for"),
+        ("0.11.0", FRAGMENT.replace("v0.12.0", "v0.11.0"), "already contains"),
+        ("0.10.0", FRAGMENT.replace("v0.12.0", "v0.10.0"), "already contains"),
+        ("0.9.0", FRAGMENT.replace("v0.12.0", "v0.9.0"), "not newer than"),
+        ("0.12.0", "loose prose\n\n" + FRAGMENT, "begin with its section heading"),
+        ("0.12.0", FRAGMENT + "\n## v0.13.0 (2026-07-23)\n\n- oops\n", "exactly one"),
+        ("0.12.0", "no heading at all\n", "exactly one"),
+        ("0.12", FRAGMENT, "plain three-part version"),
+    ],
+)
+def test_bad_input_is_refused_without_touching_anything(
+    repo: tuple[Path, Path], version: str, fragment: str, expected: str
+) -> None:
+    """Every rejection must leave both files exactly as they were."""
+    changelog, manifest = repo
+    before_changelog = changelog.read_text(encoding="utf-8")
+    before_manifest = manifest.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match=expected):
+        prepare(version, fragment, changelog, manifest)
+
+    assert changelog.read_text(encoding="utf-8") == before_changelog
+    assert manifest.read_text(encoding="utf-8") == before_manifest
+
+
+def test_an_unreleased_section_blocks_preparation(repo: tuple[Path, Path]) -> None:
+    """Prepending above Unreleased would bury it beneath the release.
+
+    Its hand-written entries would then describe a version that has already gone
+    out, while appearing to be pending.
+    """
+    changelog, manifest = repo
+    changelog.write_text(
+        EXISTING.replace(
+            "## v0.11.0 (2026-07-20)",
+            "## [Unreleased]\n\n### Added\n\n- pending\n\n## v0.11.0 (2026-07-20)",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Unreleased"):
+        prepare("0.12.0", FRAGMENT, changelog, manifest)
+
+
+def test_preparing_the_same_release_twice_is_refused(
+    repo: tuple[Path, Path],
+) -> None:
+    """A rerun must not append a second section or a second hash."""
+    changelog, manifest = repo
+    prepare("0.12.0", FRAGMENT, changelog, manifest)
+    with pytest.raises(ValueError, match="already contains"):
+        prepare("0.12.0", FRAGMENT, changelog, manifest)
+
+
+def test_the_header_above_the_first_section_is_preserved() -> None:
+    """Everything before the first section belongs to nobody and must remain."""
+    result = prepend_section(EXISTING, FRAGMENT)
+    assert result.startswith(
+        "# Changelog\n\nSome introduction that belongs to no section.\n\n"
+    )
+
+
+def test_surrounding_blank_lines_do_not_change_the_result() -> None:
+    """Whitespace around the fragment must not leak into the file."""
+    assert prepend_section(EXISTING, "\n\n" + FRAGMENT + "\n\n\n") == prepend_section(
+        EXISTING, FRAGMENT
+    )

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -1,0 +1,141 @@
+"""Shared reading and writing of the changelog and its manifest.
+
+Both the integrity test and the release preparation need to agree on what a
+section is and how it is hashed. Two implementations would eventually disagree,
+and the disagreement would surface as a released section that no longer matches
+the hash recorded for it -- which is the exact failure this machinery exists to
+prevent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+
+# Two heading styles have to be recognised. Sections written before releases
+# were generated look like "## [0.11.0] - 2026-07-20", and "## [Unreleased]"
+# uses the same bracketed form. Generated sections look like
+# "## v0.12.0 (2026-07-22)".
+#
+# Matching only the bracketed form would make every generated section invisible:
+# it would appear neither as published nor as unprotected, so nothing would
+# complain. The gap would be silent.
+#
+# Neither alternative matches "## Bugfix", which older sections contain as a
+# subheading at the same level and which is content, not a boundary.
+SECTION_HEADING = re.compile(
+    r"^## (?:\[(?P<bracketed>[^\]]+)\]|v(?P<generated>\d+\.\d+\.\d+))",
+    re.MULTILINE,
+)
+
+UNRELEASED = "Unreleased"
+
+
+def version_of(match: re.Match[str]) -> str:
+    """Return the version a section heading refers to.
+
+    Args:
+        match: A match of :data:`SECTION_HEADING`.
+
+    Returns:
+        The version string, without the leading ``v`` of generated headings.
+    """
+    return match.group("bracketed") or match.group("generated")
+
+
+def split_sections(text: str) -> list[tuple[str, str]]:
+    """Split a changelog into its sections.
+
+    Returns a list rather than a mapping on purpose. A mapping would silently
+    collapse two sections carrying the same version, which is exactly the state
+    a botched release would leave behind, and it would hide it from every check
+    built on top.
+
+    Args:
+        text: Full contents of the changelog.
+
+    Returns:
+        Pairs of version and the exact text of its section, heading included,
+        in the order they appear.
+    """
+    marks = [(m.start(), version_of(m)) for m in SECTION_HEADING.finditer(text)]
+    sections = []
+    for index, (start, version) in enumerate(marks):
+        end = marks[index + 1][0] if index + 1 < len(marks) else len(text)
+        sections.append((version, text[start:end]))
+    return sections
+
+
+def digest(section: str) -> str:
+    """Return the hash recorded for a section.
+
+    Args:
+        section: Exact text of one changelog section.
+
+    Returns:
+        Hex-encoded SHA-256 of the section's UTF-8 bytes.
+    """
+    return hashlib.sha256(section.encode("utf-8")).hexdigest()
+
+
+def load_manifest(path: Path) -> list[dict[str, str]]:
+    """Read the recorded section hashes.
+
+    Args:
+        path: Location of the manifest.
+
+    Returns:
+        The entries, in file order.
+    """
+    data: dict[str, list[dict[str, str]]] = json.loads(path.read_text(encoding="utf-8"))
+    return data["sections"]
+
+
+def prepend_section(changelog: str, fragment: str) -> str:
+    """Insert a new section above the first existing one.
+
+    The header above the first section is preserved untouched, and no existing
+    section is read or rewritten -- the new text is spliced in at the boundary.
+
+    Args:
+        changelog: Current contents of the changelog.
+        fragment: The new section, heading included.
+
+    Returns:
+        The changelog with the fragment inserted.
+
+    Raises:
+        ValueError: If the changelog has no section to insert above, or the
+            fragment is not exactly one section.
+    """
+    fragment = fragment.strip("\n") + "\n\n"
+    sections = split_sections(fragment)
+    if len(sections) != 1:
+        raise ValueError(
+            f"the fragment must contain exactly one section, found {len(sections)}"
+        )
+    # Without this, loose prose above the heading is carried into the file: the
+    # fragment still parses as one section, because everything before the first
+    # heading belongs to no section and is silently ignored.
+    if not fragment.startswith("## "):
+        raise ValueError("the fragment must begin with its section heading")
+
+    existing = split_sections(changelog)
+    if not existing:
+        raise ValueError("the changelog contains no section to insert above")
+
+    # Inserting above an Unreleased section would bury it beneath the release
+    # and leave its hand-written entries describing a version that has already
+    # gone out. Resolving that is a decision, not something to do silently.
+    if any(version == UNRELEASED for version, _ in existing):
+        raise ValueError(
+            "the changelog still has an Unreleased section; fold it into the "
+            "release or remove it before preparing one"
+        )
+
+    first = SECTION_HEADING.search(changelog)
+    assert first is not None  # noqa: S101 - guaranteed by the check above
+    return changelog[: first.start()] + fragment + changelog[first.start() :]

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -1,0 +1,192 @@
+"""Insert a release section into the changelog and freeze it in the manifest.
+
+Called by the release workflow after commitizen has determined the next version
+and produced the section text. Kept out of the workflow so the part that edits
+protected history can be tested rather than only observed in production.
+
+Everything is validated in memory first. An earlier version wrote the changelog
+and only then noticed a mismatched version, leaving the file dirty and the
+manifest untouched -- a half-finished state in the middle of a release.
+
+Usage::
+
+    python tools/prepare_release.py <version> <fragment-file>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from changelog import (
+    UNRELEASED,
+    digest,
+    prepend_section,
+    split_sections,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+MANIFEST = REPO_ROOT / ".changelog-manifest.json"
+
+
+def _as_tuple(version: str) -> tuple[int, ...]:
+    """Return a comparable form of a plain version.
+
+    Args:
+        version: A version such as ``0.12.0``.
+
+    Returns:
+        Its numeric components.
+
+    Raises:
+        ValueError: If the version is not three plain numbers.
+    """
+    parts = version.split(".")
+    if len(parts) != 3 or not all(p.isdigit() for p in parts):
+        raise ValueError(
+            f"{version!r} is not a plain three-part version; this path does "
+            "not handle prereleases"
+        )
+    return tuple(int(p) for p in parts)
+
+
+def validate(
+    version: str, fragment: str, changelog: str, manifest: list[dict[str, str]]
+) -> None:
+    """Check every precondition before anything is written.
+
+    Args:
+        version: Version about to be released.
+        fragment: The section text produced by commitizen.
+        changelog: Current contents of the changelog.
+        manifest: Recorded entries.
+
+    Raises:
+        ValueError: If the release must not be prepared.
+    """
+    target = _as_tuple(version)
+
+    sections = split_sections(fragment)
+    if len(sections) != 1:
+        raise ValueError(
+            f"the fragment must contain exactly one section, found {len(sections)}"
+        )
+    # The version is passed separately from the fragment, so they can disagree.
+    # Catching that here rather than after writing keeps the tree clean.
+    fragment_version = sections[0][0]
+    if fragment_version != version:
+        raise ValueError(
+            f"the fragment is for {fragment_version}, but {version} was requested"
+        )
+
+    existing = [v for v, _ in split_sections(changelog)]
+    if version in existing:
+        raise ValueError(
+            f"the changelog already contains a section for {version}; "
+            "a released version is never written twice"
+        )
+    if any(entry["version"] == version for entry in manifest):
+        raise ValueError(f"the manifest already records {version}")
+
+    released = [v for v in existing if v != UNRELEASED]
+    for previous in released:
+        try:
+            if _as_tuple(previous) >= target:
+                raise ValueError(
+                    f"{version} is not newer than {previous}, which the "
+                    "changelog already contains"
+                )
+        except ValueError as error:
+            if "not a plain three-part version" not in str(error):
+                raise
+            # Historic sections predate this scheme; they cannot be compared
+            # and are not a reason to refuse a release.
+
+
+def prepare(
+    version: str,
+    fragment: str,
+    changelog_path: Path = CHANGELOG,
+    manifest_path: Path = MANIFEST,
+) -> str:
+    """Insert the section and record its hash.
+
+    Args:
+        version: Version being released.
+        fragment: The section text produced by commitizen.
+        changelog_path: Location of the changelog.
+        manifest_path: Location of the manifest.
+
+    Returns:
+        A short report of what was written.
+
+    Raises:
+        ValueError: If a precondition fails, or the result does not match what
+            was intended. Nothing is written in either case.
+    """
+    changelog = changelog_path.read_text(encoding="utf-8")
+    payload: dict[str, list[dict[str, str]]] = json.loads(
+        manifest_path.read_text(encoding="utf-8")
+    )
+    manifest = payload["sections"]
+
+    validate(version, fragment, changelog, manifest)
+
+    updated = prepend_section(changelog, fragment)
+
+    # Verify the intended outcome on the in-memory result, before either file is
+    # touched. Hashing the fragment instead would freeze text that differs from
+    # the file by whitespace, and the mismatch would only surface later.
+    written = dict(split_sections(updated)).get(version)
+    if written is None:
+        raise ValueError(
+            f"the section for {version} is not present after insertion; "
+            "its heading is probably not in a recognised format"
+        )
+    before = dict(split_sections(changelog))
+    after = dict(split_sections(updated))
+    for existing_version, section in before.items():
+        if after.get(existing_version) != section:
+            raise ValueError(
+                f"the section for {existing_version} changed while inserting "
+                f"{version}; refusing to write"
+            )
+
+    payload["sections"] = [*manifest, {"version": version, "sha256": digest(written)}]
+
+    changelog_path.write_text(updated, encoding="utf-8")
+    manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    return (
+        f"Inserted {version} and recorded its hash "
+        f"({len(payload['sections'])} entries)."
+    )
+
+
+def main(argv: list[str]) -> int:
+    """Run the preparation.
+
+    Args:
+        argv: Version and path to the fragment file.
+
+    Returns:
+        Process exit code.
+    """
+    if len(argv) != 2:
+        print(f"usage: {sys.argv[0]} <version> <fragment-file>", file=sys.stderr)
+        return 2
+
+    version, fragment_path = argv
+    try:
+        print(prepare(version, Path(fragment_path).read_text(encoding="utf-8")))
+    except ValueError as error:
+        print(f"Refusing to prepare the release: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Part of #864 (phase 6), first half. The workflow follows separately — splitting it this way means the part that edits protected history is tested before anything can publish.

Reviewed adversarially with Codex, which found a **real bug my own end-to-end test had hidden**. Details below.

## The bug the review caught

My end-to-end run against the real changelog reported *"19 → 20 sections, no existing section changed"*. Both were true, and the result was still wrong — I had never checked the **order**:

```
## v0.12.0 (2026-07-22)   ← inserted
## [Unreleased]           ← buried beneath the release
## [0.11.0] - 2026-07-20
```

The `[Unreleased]` section would end up below the release, still holding hand-written entries that describe a version which has already gone out — including the Security note that commitizen cannot regenerate, because that change landed as `chore(deps)`.

**Preparing a release is now refused while an `Unreleased` section exists.** Resolving it is a decision, not something to do silently — and it is exactly the state this repository is in today. Verified: running the script against the real changelog now exits 1 with a clear message and touches neither file.

## What else the review changed

**Validation before mutation.** The earlier version wrote the changelog and *then* noticed a version mismatch, leaving a dirty file mid-release. Everything is now checked in memory first, and only a verified result is written.

**A prefix bypass.** `prepend_section` accepted loose prose above the heading: the fragment still parsed as one section, because text before the first heading belongs to no section and was silently ignored. It now must begin with its heading.

**A tautological test.** One assertion read `digest(written) == digest(written)` — it could not fail. It now compares the recorded hash against the file *and* asserts that the file and the input fragment actually differ, so the comparison is meaningful.

**Tests that never called the thing they test.** The suite exercised only the splice helper. It now drives `prepare()` against temporary files, covering the manifest append, the write ordering, and eight rejection cases — each asserting that **both files are untouched** afterwards.

## What is enforced

| Precondition | Behaviour |
| --- | --- |
| Fragment is exactly one section, beginning with its heading | else refused |
| Fragment version equals the requested version | else refused |
| Version absent from changelog and manifest | else refused |
| Version newer than every comparable released one | else refused |
| No `Unreleased` section present | else refused |
| Every pre-existing section byte-identical in the result | else refused, nothing written |

The hash is taken from the section **as it lands in the file**, not from the fragment handed in, so a whitespace difference cannot produce a manifest that disagrees with the file it describes.

## Also

`tools/changelog.py` now holds the parsing and hashing that the integrity test and the release share. Two implementations would eventually diverge, and the divergence would surface as a released section no longer matching its recorded hash. mypy now covers `tools/`.

## Verification

- 22 changelog and release tests, 161 in total
- Running the script against the real changelog is refused, both files untouched
- `uv run nox` — all 16 sessions green
