### PR TITLE
ci: require conventional commit titles on pull requests

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -86,13 +86,15 @@ jobs:
           Accepted types: build, chore, ci, docs, feat, fix, perf, refactor,
           revert, style, test.
 
-          Only four of them reach a release. feat raises the minor version; fix,
-          perf and refactor raise the patch version. Those same four are the
-          whole of commitizen's change_type_map, so everything else -- including
-          revert -- appears in no changelog section and bumps nothing. Valid is
-          not the same as recorded. If users should read about the change, pick
-          a type that reaches them: a revert of a released fix is best titled
-          for its effect, e.g. `fix(auth): restore the previous token header`.
+          Of these, feat raises the minor version, and fix and perf raise the
+          patch version; a breaking change (`!` after the type, or a
+          BREAKING CHANGE footer) always releases. Everything else --
+          including refactor and revert -- appears in no changelog section and
+          releases nothing by default; a `Changelog:` footer as the last
+          paragraph of the description can override that (see cliff.toml).
+          Valid is not the same as recorded: if users should read about the
+          change, pick a type that reaches them, e.g.
+          `fix(auth): restore the previous token header` for a revert.
 
           Note that "Merge ...", "Revert \"...\"" and "fixup! ..." are rejected
           here even though commitizen ships with them allowed -- see the comment

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,101 @@
+name: PR Title
+
+# The pull request title is the commit message. This repository merges by squash
+# only, with squash_merge_commit_title set to PR_TITLE and
+# squash_merge_commit_message set to PR_BODY, so the title and description land
+# on master as one commit -- and commitizen reads that commit to decide the next
+# version and to write the changelog.
+#
+# A message it cannot parse produces no changelog entry and no release, and does
+# so silently: "no releasable commits" is exactly what a quiet week looks like.
+# That is worth catching before the merge rather than noticing weeks later that
+# a fix never shipped.
+
+on:
+  pull_request:
+    # `edited` is what makes this usable: without it a corrected title is never
+    # re-checked, so the failed check would block the merge forever. It also
+    # covers the description, which becomes the commit body.
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  UV_VERSION: "0.11.28"
+
+jobs:
+  check:
+    name: pr-title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the base branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The base commit, not the pull request. This runs for forks, and
+          # nothing here needs the proposed code -- only the repository's own
+          # commitizen configuration. A pull request that changes that
+          # configuration is therefore still judged by the configuration the
+          # base branch has today.
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version: "3.14"
+
+      - name: Install commitizen
+        run: uv sync --no-install-project --group release
+
+      - name: Check the commit message
+        env:
+          # Passed through the environment, never interpolated into the script:
+          # both are attacker-controlled text on a fork pull request.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Assembled the way GitHub assembles the squash commit, and checked as
+          # one message rather than as a bare subject line, so what is validated
+          # is what will actually be committed.
+          message="$RUNNER_TEMP/commit.txt"
+          printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" > "$message"
+
+          # commitizen rather than a hand-written pattern, deliberately. This has
+          # to enforce exactly the pattern that later decides the version bump; a
+          # second copy of it would drift, and the drift would admit titles the
+          # release path then ignores -- the very failure being prevented.
+          if uv run --no-sync python -m commitizen check --commit-msg-file "$message"; then
+            exit 0
+          fi
+
+          echo "::error::The title is not a conventional commit, so merging it would produce no changelog entry and no release."
+          cat <<'GUIDE'
+
+          The title becomes the commit subject on master. It must read like:
+
+            fix(client): handle expired refresh tokens
+            feat(auth): add browser-based login
+            refactor(cli)!: remove the legacy command parser
+
+          Accepted types: build, chore, ci, docs, feat, fix, perf, refactor,
+          revert, style, test.
+
+          Only four of them reach a release. feat raises the minor version; fix,
+          perf and refactor raise the patch version. Those same four are the
+          whole of commitizen's change_type_map, so everything else -- including
+          revert -- appears in no changelog section and bumps nothing. Valid is
+          not the same as recorded. If users should read about the change, pick
+          a type that reaches them: a revert of a released fix is best titled
+          for its effect, e.g. `fix(auth): restore the previous token header`.
+
+          Note that "Merge ...", "Revert \"...\"" and "fixup! ..." are rejected
+          here even though commitizen ships with them allowed -- see the comment
+          on allowed_prefixes in pyproject.toml.
+          GUIDE
+          exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,21 @@ required-version = ">=0.7.1"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
+# commitizen's default allows "Merge", "Revert", "Pull request", "fixup!",
+# "squash!" and "amend!" to bypass validation entirely -- `cz check` returns
+# success for "Merge nonsense". Those prefixes exist for repositories that merge
+# rather than squash; here the pull request title *is* the commit subject, and a
+# title commitizen waves through but later ignores produces no changelog entry
+# and no release, silently. Emptying the list closes that hole for every caller,
+# so the pull request check and the master check cannot disagree.
+#
+# Consequence worth knowing: GitHub's Revert button proposes "Revert \"...\"",
+# which is now rejected. `revert: ...` is accepted, but be aware that it is not
+# the same as being recorded -- commitizen's change_type_map covers only feat,
+# fix, refactor and perf, so a revert produces neither a changelog entry nor a
+# version bump. If undoing the change is something users should read about,
+# title it for its effect, e.g. `fix(auth): restore the previous token header`.
+allowed_prefixes = []
 # Reads and writes the version in pyproject.toml *and* uv.lock, so the two
 # cannot drift apart during a release.
 version_provider = "uv"


### PR DESCRIPTION
Part of #864. One required check: the pull request title must parse as a conventional commit.

## Why

The repository squash-merges with the title as the commit subject, and commitizen reads that commit to decide the version and write the changelog. Measured on a clone by tagging master and adding a single commit:

```
only "Fix a real crash in the client" since the tag
  -> "The commits found are not eligible to be bumped"
the same fix as "fix(client): a real crash"
  -> 0.11.2
```

A bugfix with a careless title merges green and then produces no changelog entry and no release — indistinguishable from a quiet week. Nothing checked this today.

Blocking the *commit* is not possible here: `commit_message_pattern` and `merge_queue` rulesets are both rejected by the API for this repository, while ordinary rules on the same repository are accepted — metadata restrictions require an organisation on an Enterprise plan. So the check sits on the pull request, where it can block the merge.

## commitizen's default made the check a no-op

`cz check` ships with `allowed_prefixes` covering `Merge`, `Revert`, `Pull request`, `fixup!`, `squash!` and `amend!`:

```
exit=0  Merge nonsense
exit=0  Revert "feat: x"
exit=0  Pull request #5
exit=0  fixup! whatever
```

Those are exactly the subjects commitizen later ignores, so the check would have been green and useless. `allowed_prefixes = []` closes it for every caller, so this check and the release path cannot disagree.

Consequence: GitHub's Revert button proposes `Revert "..."`, which is now rejected. `revert:` is accepted — but records nothing, because `change_type_map` holds only feat, fix, refactor and perf. If the undoing matters to users, title it for its effect.

## Scope

The message is assembled the way GitHub assembles the squash commit — title, blank line, description — and checked with `--commit-msg-file`, so what is validated is what will actually be committed.

An earlier version of this pull request also checked whether the *description* silently changes the released version. That is a real effect: a `fix(...)` commit whose description contains a line beginning `feat:` at column zero releases 0.12.0 instead of 0.11.2, and a fenced code block is no protection, because commitizen reads a commit message rather than markdown. It was dropped anyway, because it never fires in practice here — across the last six Renovate and Dependabot pull requests, zero would have triggered it, since Renovate keeps embedded changelogs inside `<details>` blocks. It cost a script, seventeen tests and four non-public commitizen imports to guard a case this repository has never seen, and a wrong version number is visible in the release pull request's own title before anything is published.

That work is preserved on branch `ci/pr-body-check-parked` if it is ever wanted.

## Note on the first run

Verified locally against six message shapes: good titles with empty and long descriptions pass, a careless title and the `Merge`/`Revert` prefixes are rejected, `revert:` passes.

## Verification

- `uv run nox` — all 16 sessions green
- Behaviour of the assembled-message check verified case by case
