### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/.changelog-manifest.json
+++ b/.changelog-manifest.json
@@ -72,6 +72,10 @@
     {
       "version": "0.4.4",
       "sha256": "4c662d252a176c19277d7c85bc4f1e3dfbcf7b3a1485a8faadb05ace7201bb51"
+    },
+    {
+      "version": "0.12.0",
+      "sha256": "baace9394679e9cdabf9188ec6aabb0baad6eb3b768758fd239e36b58aa8b5ab"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New entries are generated from Conventional Commit messages and are
 grouped by commit type. Sections below that predate this are kept as they
 were written; the wording of a published entry never changes.
 
-## [Unreleased]
+## [0.12.0] - 2026-07-23
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "audible"
-version = "0.11.0"
+version = "0.12.0"
 description = "A(Sync) Interface for internal Audible API written in pure Python."
 authors = [{ name = "mkb79", email = "mkb79@hackitall.de" }]
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -89,7 +89,7 @@ wheels = [
 
 [[package]]
 name = "audible"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
The first release under the new machinery, and the one release whose changelog section is **not generated**: the hand-written `[Unreleased]` section becomes `[0.12.0]` verbatim — the diff to `CHANGELOG.md` is a single heading line. It contains the Security note about raised dependency floors, which no generator can reproduce (that change landed as `chore(deps)`), and generation starts cleanly with 0.13.0.

> [!IMPORTANT]
> **Merging this pull request publishes v0.12.0.** After CI passes on master, `release.yml` will recognise the squash commit, re-verify coherence, build reproducibly, smoke-test wheel and sdist, then create the tag `v0.12.0` (via the release app), upload to PyPI via trusted publishing, and create the GitHub release with the section below as its body — byte for byte, frozen in the manifest, watched by the scheduled drift audit.
>
> Closing it publishes nothing.

What this pull request changes:

| file | change |
| --- | --- |
| `CHANGELOG.md` | one line: `## [Unreleased]` → `## [0.12.0] - 2026-07-23` |
| `.changelog-manifest.json` | appends the frozen hash of that section (19th entry) |
| `pyproject.toml` + `uv.lock` | `0.11.0` → `0.12.0`, together via `uv version` |

Verified before opening:

- `tools/verify_release_commit.py 0.12.0` — the exact gate `release.yml` runs — passes: pyproject, lock, changelog and manifest agree
- `check_manifest_append_only.py` against master: *18 kept, 1 added*
- 45 changelog/release tests, all 16 nox sessions green
- The pipeline itself was rehearsed end to end yesterday: `0.11.0.dev29981383754` went through build, twine, both smoke tests and trusted publishing to TestPyPI, and installs from there

Why this is hand-crafted rather than generated: the automation refuses to prepare a release while an `Unreleased` section exists — burying hand-written entries beneath a generated section was the first bug the adversarial reviews caught, and refusing is the designed behaviour. Folding it is the one decision a tool cannot make. From 0.13.0 on, `release-pr.yml` proposes automatically.
