### PR TITLE
ci(release): conclude tag absence only from an explicit 404

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,8 +215,23 @@ jobs:
           VERSION: ${{ needs.inspect.outputs.version }}
           SHA: ${{ needs.inspect.outputs.sha }}
         run: |
-          existing="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/v$VERSION" \
-                        --jq .object.sha 2>/dev/null || true)"
+          # gh api prints the error JSON to *stdout* on an HTTP error --
+          # measured: a 404 put {"message":"Not Found",...} into the capture,
+          # which the first production run then treated as a mismatching tag
+          # and hard-stopped. Absence is only ever concluded from an explicit
+          # HTTP 404 on stderr; any other failure (network, auth) stops the
+          # release rather than risking a create over an unknown state.
+          if existing="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/v$VERSION" \
+                           --jq .object.sha 2>"$RUNNER_TEMP/tag-lookup.err")"; then
+            :
+          elif grep -q "HTTP 404" "$RUNNER_TEMP/tag-lookup.err"; then
+            existing=""
+          else
+            cat "$RUNNER_TEMP/tag-lookup.err" >&2
+            echo "::error::Could not determine whether v$VERSION exists."
+            exit 1
+          fi
+
           if [ -z "$existing" ]; then
             gh api "repos/$GITHUB_REPOSITORY/git/refs" \
               -f ref="refs/tags/v$VERSION" -f sha="$SHA" >/dev/null


### PR DESCRIPTION
The first production run of #878 failed in the tag job: `gh api` prints the error JSON to **stdout** on an HTTP error, so the 404 of the not-yet-existing tag was captured as if it were a pointing-elsewhere tag, and the guard hard-stopped.

**State is clean** — verified live: no tag `v0.12.0`, PyPI still 404. The failure fell in the safe direction.

The lookup now concludes absence **only** from an explicit `HTTP 404` on stderr; success yields the sha; any other failure (network, auth) stops the release rather than creating over unknown state — which also closes the fail-open the adversarial review had flagged for real errors. All three branches measured against the live API before opening this.

**Heal path after merging:** re-run the CI workflow on the release commit `9757586`. Its fresh `workflow_run` completion triggers `release.yml` — which by then is this fixed version, since workflow_run always runs the default-branch file — and the release proceeds with the tag logic corrected. No manual publish lever needed.