### PR TITLE
ci(release): read the tag with the workflow token, create with the app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,18 +202,29 @@ jobs:
         id: app-token
         # The v* tag ruleset restricts creation to the release app -- the
         # workflow's own token could not create this tag even with
-        # contents: write. Narrowed to contents; nothing here needs more.
+        # contents: write.
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
+          # Without this, the narrowed token answered REST reads with 403
+          # "Resource not accessible by integration" -- while git-protocol
+          # access with the same token worked. Most repository REST endpoints
+          # sit behind metadata read, which an unnarrowed installation token
+          # carries implicitly and the narrowing dropped.
+          permission-metadata: read
 
-      - name: Create the tag, or verify it
+      - name: Look up the tag
+        id: lookup
+        # Deliberately with the workflow's own read token, not the app token:
+        # the read has to keep working even when something is wrong with the
+        # app, because it is this lookup that tells a retried run whether the
+        # state it sees is its own earlier progress. Only the *create* needs
+        # the app.
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.inspect.outputs.version }}
-          SHA: ${{ needs.inspect.outputs.sha }}
         run: |
           # gh api prints the error JSON to *stdout* on an HTTP error --
           # measured: a 404 put {"message":"Not Found",...} into the capture,
@@ -231,16 +242,24 @@ jobs:
             echo "::error::Could not determine whether v$VERSION exists."
             exit 1
           fi
+          echo "existing=$existing" >> "$GITHUB_OUTPUT"
 
-          if [ -z "$existing" ]; then
+      - name: Create the tag, or verify it
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ needs.inspect.outputs.version }}
+          SHA: ${{ needs.inspect.outputs.sha }}
+          EXISTING: ${{ steps.lookup.outputs.existing }}
+        run: |
+          if [ -z "$EXISTING" ]; then
             gh api "repos/$GITHUB_REPOSITORY/git/refs" \
               -f ref="refs/tags/v$VERSION" -f sha="$SHA" >/dev/null
             echo "Created v$VERSION at $SHA."
-          elif [ "$existing" = "$SHA" ]; then
+          elif [ "$EXISTING" = "$SHA" ]; then
             # A retried run after a later failure: the tag is already right.
             echo "v$VERSION already points at $SHA."
           else
-            echo "::error::v$VERSION exists but points at $existing, not $SHA."
+            echo "::error::v$VERSION exists but points at $EXISTING, not $SHA."
             echo "This release was prepared for a different commit; do not proceed."
             exit 1
           fi


### PR DESCRIPTION
Second finding from the live release of #878, after the 404-handling fix of #879 worked as designed and failed closed on something new: the narrowed app token got **403 "Resource not accessible by integration"** on the REST ref lookup — while git-protocol access with the same token (the release-pr checkout) worked. Most repository REST endpoints sit behind **metadata: read**, which an unnarrowed installation token carries implicitly and our `permission-contents`-only narrowing dropped.

Two changes, each sufficient alone:

- the lookup now uses the workflow's own read token — the read must keep working even when something is wrong with the app, because it is what tells a retried run whether the state it sees is its own earlier progress; only the *create* needs the app
- the mint requests `permission-metadata: read` explicitly, so the app token can use REST reads again

State remains clean and verified: no tag, PyPI 404. **Heal path after merging:** re-run the failed jobs of run 29986832144 — outputs and the built artifact of the green jobs are preserved, so the release resumes at the tag.