### PR TITLE
ci(release): mint the tag token with the workflows permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,12 +208,17 @@ jobs:
           app-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
-          # Without this, the narrowed token answered REST reads with 403
-          # "Resource not accessible by integration" -- while git-protocol
-          # access with the same token worked. Most repository REST endpoints
-          # sit behind metadata read, which an unnarrowed installation token
-          # carries implicitly and the narrowing dropped.
-          permission-metadata: read
+          # Creating a tag needs more than contents when the target commit's
+          # workflow files differ from the branch heads: GitHub then treats
+          # the tag as making those workflow versions reachable and demands
+          # the workflows permission of apps -- over git as an explicit
+          # "refusing to allow a GitHub App to create or update workflow"
+          # (GH013), over REST as a bare 403. In normal operation the tag is
+          # created minutes after the merge, while the release commit still
+          # is the head, and the requirement never triggers. A *retried*
+          # release with fixes merged in between is exactly when it does --
+          # measured, six failed runs long.
+          permission-workflows: write
 
       - name: Look up the tag
         id: lookup


### PR DESCRIPTION
The last missing piece after this morning's six-run diagnosis, root cause finally named verbatim by the git-protocol probe:

```
refusing to allow a GitHub App to create or update workflow
.github/workflows/release.yml without workflows permission  (GH013)
```

Tagging a commit whose workflow files differ from the branch heads requires the **workflows** permission of apps — over REST this surfaced as a bare 403, though the response header `x-accepted-github-permissions: contents=write; contents=write,workflows=write` had named the condition all along. Normal operation never triggers it (the tag lands while the release commit is still the head); a *retried* release with fixes merged in between — today's exact situation — always does. The app now holds Workflows read & write (granted by @mkb79); this mints the token with it. Codex verified the input against the pinned action schema and the documented endpoint requirements, and assessed the added surface as well-contained (repo-scoped token, no checked-out code in the job, SHA-pinned action, post-step revocation).

**Removed on review:** the `permission-metadata: read` narrowing. Its 403 attribution was wrong — the causes were this workflows requirement plus the platform incident (Actions partial_outage, resolved 09:21 UTC) — and since the lookup moved to the workflow's own token, no app-token operation needs metadata. Least privilege over 'harmless'.

**What stays from the earlier fixes, deliberately:** the 404-only-from-stderr handling (#879, a real bug) and the lookup via the workflow token (#880 — proved its worth today: reads keep working and diagnosing even while the app path is broken).

**After merging — corrected:** do NOT re-run the failed jobs of run 29988808513; re-runs pin the workflow file of the original run and would mint without the new permission. Instead re-run the CI workflow of release commit `9757586`: its fresh workflow_run completion creates a new Release run from the post-merge file. The fresh run rebuilds reproducibly, so the artifact of the old run is not needed.