### PR TITLE
ci: set workflow-level token permissions on claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,17 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Read-only by default, matching every other workflow here. The claude job
+# overrides this with the exact set it needs. Without a workflow-level block the
+# default token permissions apply to any job that does not set its own, which
+# OSSF Scorecard flags (TokenPermissions).
+#
+# Note this bounds only the GITHUB_TOKEN. What the Claude GitHub App itself can
+# reach is governed by its installation permissions in repository settings, not
+# by this block -- tighten there if the app's access needs narrowing further.
+permissions:
+  contents: read
+
 jobs:
   claude:
     if: |


### PR DESCRIPTION
Resolves the OSSF Scorecard **TokenPermissions** alert #13 on `claude.yml:1`.

The workflow declared `permissions` only at the job level, so it had no workflow-level default — Scorecard flags this, because a job without its own block would inherit the broad default `GITHUB_TOKEN`. Every other workflow here already sets a top-level `permissions: contents: read`; this brings `claude.yml` in line. The claude job keeps its exact set (reads plus `id-token: write`).

A comment records the honest limit, which is the phase-8 item's point: this bounds the **GITHUB_TOKEN**, not the **Claude GitHub App's** own installation access — that is governed in repository settings, not by a workflow `permissions` block. Narrow there if the app's reach needs tightening further.

The alert closes on the next Scorecard run (schedule/push to master); it can also be dismissed once this merges.