### PR TITLE
ci(deps): type build-constraints.txt updates as build(deps)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -102,6 +102,19 @@
       semanticCommitScope: 'deps',
     },
     {
+      // build-constraints.txt pins hatchling, the build backend. Without this
+      // the pip_requirements manager falls back to config:recommended's
+      // chore(deps), inconsistent with the pinned uv above -- both are pinned
+      // release infrastructure. build(deps) is the precise conventional type
+      // for the build system; like ci and chore, it does not trigger a release.
+      description: 'Pinned build backend is build tooling',
+      matchManagers: [
+        'pip_requirements',
+      ],
+      semanticCommitType: 'build',
+      semanticCommitScope: 'deps',
+    },
+    {
       description: 'Customize lockFileMaintenance PR labels/grouping',
       matchUpdateTypes: [
         'lockFileMaintenance',


### PR DESCRIPTION
Closes the last commit-type gap from the phase-8 policy. `build-constraints.txt` pins hatchling (the build backend, added in #876), but the `pip_requirements` manager had **no** `semanticCommitType` rule — so a hatchling bump would fall back to `config:recommended`'s `chore(deps)`, inconsistent with the pinned uv version right above it, which we type `ci(deps)`.

Both are pinned release infrastructure and neither should release. `build(deps)` is the precise conventional-commit type for the build system — distinct from `ci` (CI-run tooling: actions, uv) and `chore` (generic maintenance). Like both, it is skipped by cliff.toml, so it never triggers a release.

One packageRule, matched on the `pip_requirements` manager.