### PR TITLE
ci: point the dependency-review-action pin comment at its real tag

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Review dependency changes
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
           # No license policy is defined for this project, so do not invent one


### PR DESCRIPTION
Fixes the Renovate lookup failure reported on the dependency dashboard (#813):

> Could not determine new digest for update (github-tags package actions/dependency-review-action). Files affected: `.github/workflows/security.yml`

**Cause.** The pin carried `# v5`, but `actions/dependency-review-action` publishes **no moving `v5` tag** — only `v5.0.0` (verified: `git/ref/tags/v5` → 404, `git/ref/tags/v5.0.0` → the pinned SHA a1d282b3). Renovate reads the comment as the current version, has no `v5` tag to diff against, and gives up on the digest. Actions like `checkout # v7` don't hit this because they *do* publish a moving major tag.

**Fix.** The SHA is unchanged and already correct; only the comment now names the tag it actually resolves to — `# v5.0.0`. Renovate can then track and bump it normally.

Audited all twelve SHA-pinned actions: this was the only one whose comment tag did not resolve.