### PR TITLE
refactor(client): import HeaderTypes from its defining httpx module

### DIFF
--- a/src/audible/client.py
+++ b/src/audible/client.py
@@ -19,7 +19,7 @@ import httpx
 # namespace of the module using the annotation. Without the binding, tools that
 # evaluate annotations (sphinx-autodoc-typehints among them) cannot resolve it.
 from httpx import URL, Headers
-from httpx._models import HeaderTypes  # type: ignore[attr-defined]
+from httpx._types import HeaderTypes
 
 from ._types import TrueFalseT
 from .auth import Authenticator


### PR DESCRIPTION
`client.py` imported httpx's `HeaderTypes` from `httpx._models` — a module that only *re-exports* it and forced a `# type: ignore[attr-defined]`. The symbol is actually defined in `httpx._types`.

Importing it from the defining module drops the indirection **and** the `type: ignore`, while keeping the property the maintainer wants: it still tracks httpx upstream. The annotation follows any broadening of the alias automatically, and fails **loudly** with an `ImportError` if httpx ever moves or renames the symbol.

### Why not a self-defined copy?
A hand-written alias built from public names (`httpx.Headers` + `collections.abc`) was considered and rejected: it would **freeze** the definition and diverge from httpx **silently** — the worse failure mode, and no real improvement over the private import. Codex independently reached the same conclusion and recommended this exact change.

### Scope
One line in `src/audible/client.py`; the public `Headers` binding still resolves httpx's `"Headers"` forward reference. `refactor` — behaviour-neutral, so no release and no changelog entry.

Full `uv run nox` green (16/16). This is the last open code-hardening item tracked in #864.